### PR TITLE
Support facebooks OpenR routing plattform

### DIFF
--- a/ipmininet/examples/README.md
+++ b/ipmininet/examples/README.md
@@ -142,3 +142,18 @@ This network spawn a small topology with two hosts and a router.
 One of these hosts uses Router Advertisements to get its IPv6 addresses
 The other one's IP addresses are announced in the Router Advertisements
 as the DNS server's addresses.
+
+
+## SimpleOpenRNetwork
+
+_topo name_ : simple_openr_network
+_args_ : n/a
+
+This network represents a small OpenR network connecting three routers in a Bus
+topology. Each router has hosts attached. The `/tmp` folders are private to
+isolate the unix sockets used by OpenR. The private `/var/log` directories
+isolate logs.
+
+Use
+[breeze](https://github.com/facebook/openr/blob/master/openr/docs/Breeze.md) to
+investigate the routing state of OpenR.

--- a/ipmininet/examples/__main__.py
+++ b/ipmininet/examples/__main__.py
@@ -13,6 +13,7 @@ from .iptables import IPTablesTopo
 from .gre import GRETopo
 from .sshd import SSHTopo
 from .router_adv_network import RouterAdvNet
+from .simple_openr_network import SimpleOpenrNet
 
 
 from mininet.log import lg, LEVELS
@@ -24,7 +25,8 @@ TOPOS = {'simple_ospf_network': SimpleOSPFNet,
          'iptables': IPTablesTopo,
          'gre': GRETopo,
          'ssh': SSHTopo,
-         'router_adv_network': RouterAdvNet}
+         'router_adv_network': RouterAdvNet,
+         'simple_openr_network': SimpleOpenrNet}
 
 NET_ARGS = {'router_adv_network': {'use_v4': False,
                                    'use_v6': True,

--- a/ipmininet/examples/simple_openr_network.py
+++ b/ipmininet/examples/simple_openr_network.py
@@ -1,0 +1,36 @@
+"""This file contains a simple OpenR topology"""
+
+from ipmininet.iptopo import IPTopo
+from ipmininet.router.config import RouterConfig, OpenrDaemon, Openr
+
+HOSTS_PER_ROUTER = 2
+
+
+class OpenrConfig(RouterConfig):
+    """A simple config with only a OpenR daemon"""
+    def __init__(self, node, *args, **kwargs):
+        defaults = {}
+        super(OpenrConfig, self).__init__(node,
+                                          daemons=((Openr, defaults),),
+                                          *args, **kwargs)
+
+
+class SimpleOpenrNet(IPTopo):
+    """"""
+
+    def build(self, *args, **kwargs):
+        r1 = self.addRouter_openr('r1')
+        r2 = self.addRouter_openr('r2')
+        r3 = self.addRouter_openr('r3')
+        self.addLink(r1, r2)
+        self.addLink(r1, r3)
+        for r in (r1, r2, r3):
+            for i in xrange(HOSTS_PER_ROUTER):
+                self.addLink(r, self.addHost('h%s%s' % (i, r)),
+                             params2={'v4_width': 5})
+
+        super(SimpleOpenrNet, self).build(*args, **kwargs)
+
+    def addRouter_openr(self, name):
+        return self.addRouter(name, config=OpenrConfig,
+                              privateDirs=['/tmp', '/var/log'])

--- a/ipmininet/router/config/__init__.py
+++ b/ipmininet/router/config/__init__.py
@@ -9,8 +9,10 @@ from .radvd import RADVD, AdvPrefix, AdvRDNSS
 from .iptables import IPTables, IP6Tables
 from .sshd import SSHd
 from .pimd import PIMD
+from .openrd import OpenrDaemon
+from .openr import Openr
 
-__all__ = ['BasicRouterConfig', 'Zebra', 'OSPF', 'OSPF6', 'OSPFArea', 'BGP', 'AS',
-           'iBGPFullMesh', 'bgp_peering', 'RouterConfig', 'bgp_fullmesh',
-           'ebgp_session', 'IPTables', 'IP6Tables', 'SSHd', 'RADVD', 'AdvPrefix',
-           'AdvRDNSS', 'PIMD']
+__all__ = ['BasicRouterConfig', 'Zebra', 'OSPF', 'OSPF6', 'OSPFArea', 'BGP',
+           'AS', 'iBGPFullMesh', 'bgp_peering', 'RouterConfig', 'bgp_fullmesh',
+           'ebgp_session', 'IPTables', 'IP6Tables', 'SSHd', 'RADVD',
+           'AdvPrefix', 'AdvRDNSS', 'PIMD', 'Openrd', 'Openr']

--- a/ipmininet/router/config/openr.py
+++ b/ipmininet/router/config/openr.py
@@ -1,0 +1,111 @@
+"""Base classes to configure an OpenR daemon"""
+from ipaddress import ip_interface
+
+from ipmininet.iptopo import Overlay
+from ipmininet.utils import otherIntf, L3Router, realIntfList
+from .utils import ConfigDict
+from .openrd import OpenrDaemon
+
+
+class OpenrDomain(Overlay):
+    """An overlay to group OpenR links and routers by domain"""
+
+    def __init__(self, domain, routers=(), links=(), **props):
+        """:param domain: the domain for this overlay
+        :param routers: the set of routers for which all their interfaces
+                        belong to that area
+        :param links: individual links belonging to this area"""
+        super(OpenrDomain, self).__init__(nodes=routers, links=links,
+                                          nprops=props)
+        self.domain = domain
+
+    @property
+    def domain(self):
+        return self.link_properties['openr_domain']
+
+    @domain.setter
+    def domain(self, x):
+        self.link_properties['openr_domain'] = x
+
+    def apply(self, topo):
+        # Add all links for the routers
+        for r in self.nodes:
+            self.add_link(*topo.g[r])
+        super(OpenrDomain, self).apply(topo)
+
+    def __str__(self):
+        return '<OpenR domain %s>' % self.domain
+
+
+class Openr(OpenrDaemon):
+    """This class provides a simple configuration for an OpenR daemon."""
+    NAME = 'openr'
+    DEPENDS = (OpenrDaemon,)
+    KILL_PATTERNS = (NAME,)
+
+    def __init__(self, node, *args, **kwargs):
+        super(Openr, self).__init__(node=node, *args, **kwargs)
+
+    def build(self):
+        cfg = super(Openr, self).build()
+        for key in self._default_config().keys():
+            cfg[key] = self.options[key]
+        cfg.node_name = self._node.name
+        interfaces = [itf
+                      for itf in realIntfList(self._node)]
+        cfg.interfaces = self._build_interfaces(interfaces)
+        cfg.networks = self._build_networks(interfaces)
+        cfg.prefixes = self._build_prefixes(interfaces)
+        cfg.update(cfg_overwrite)
+        return cfg
+
+    def _build_networks(self, interfaces):
+        """Return the list of OpenR networks to advertize from the list of
+        active OpenR interfaces"""
+        # Check that we have at least one IPv4 network on that interface ...
+        return [OpenrNetwork(domain=ip_interface(
+            u'%s/%s' % (i.ip, i.prefixLen))) for i in interfaces if i.ip]
+
+    def _build_interfaces(self, interfaces):
+        """Return the list of OpenR interface properties from the list of
+        active interfaces"""
+        return [ConfigDict(description=i.describe,
+                           name=i.name,
+                           # Is the interface between two routers?
+                           active=self.is_active_interface(i),
+                           ) for i in interfaces]
+
+    def _build_prefixes(self, interfaces):
+        ipv6_addresses = reduce(lambda x, y: x + y.addresses[6],
+                                interfaces, [])
+        ipv6_addresses = filter(lambda x: not x.is_link_local, ipv6_addresses)
+        return ",".join(map(lambda x: x.with_prefixlen, ipv6_addresses))
+
+    def set_defaults(self, defaults):
+        for k, v in self._default_config().iteritems():
+            defaults[k] = v
+        super(Openr, self).set_defaults(defaults)
+
+    def _config_overwrite(self):
+        return ConfigDict(
+                          ifname_prefix="r",
+                          iface_regex_include="r.*",
+                          log_dir="/var/log")
+
+    def is_active_interface(self, itf):
+        """Return whether an interface is active or not for the OpenR daemon"""
+        return L3Router.is_l3router_intf(otherIntf(itf))
+
+
+class OpenrNetwork(object):
+    """A class holding an OpenR network properties"""
+
+    def __init__(self, domain):
+        self.domain = domain
+
+
+class OpenrPrefixes(object):
+    """A class representing a prefix type in OpenR"""
+
+    def __init__(self, prefixes):
+        self.prefixes = prefixes

--- a/ipmininet/router/config/openrd.py
+++ b/ipmininet/router/config/openrd.py
@@ -1,0 +1,50 @@
+from .base import Daemon
+from .utils import ConfigDict, template_lookup
+
+
+class OpenrDaemon(Daemon):
+    """The base class for the OpenR daemon"""
+
+    NAME = 'openr'
+
+    @property
+    def STARTUP_LINE_EXTRA(self):
+        # Add options to the standard startup line
+        return ''
+
+    @property
+    def startup_line(self):
+        return '{name} {cfg} {extra}'\
+                .format(name=self.NAME,
+                        cfg=self._cfg_options(),
+                        extra=self.STARTUP_LINE_EXTRA)
+
+    def build(self):
+        cfg = super(OpenrDaemon, self).build()
+        cfg.debug = self.options.debug
+        return cfg
+
+    def set_defaults(self, defaults):
+        """:param debug: the set of debug events that should be logged"""
+        defaults.debug = ()
+        super(OpenrDaemon, self).set_defaults(defaults)
+
+    def _cfg_options(self):
+        """The OpenR daemon has currently no option to read config from
+        configuration file itself. The run_openr.sh script can be used to read
+        options from environment files. However, we want to run the daemon
+        directly.  The default options from the shell script are implemented in
+        the openr.mako template and passed to the daemon as argument."""
+        cfg = ConfigDict()
+        cfg[self.NAME] = self.build()
+        return template_lookup.get_template(self.template_filename)\
+                              .render(node=cfg)
+
+    @property
+    def dry_run(self):
+        """The OpenR dryrun runs the daemon and does not shutdown the daemon.
+        As a workaround we only show the version of the openr daemon"""
+        # TODO: Replace with a config parser or shutdown the daemon after few
+        # seconds
+        return '{name} --version'\
+               .format(name=self.NAME)

--- a/ipmininet/router/config/openrd.py
+++ b/ipmininet/router/config/openrd.py
@@ -25,8 +25,197 @@ class OpenrDaemon(Daemon):
         return cfg
 
     def set_defaults(self, defaults):
-        """:param debug: the set of debug events that should be logged"""
-        defaults.debug = ()
+        """
+        :param alloc_prefix_len: Block size of allocated prefix in terms of
+            it's prefix length. In this case '/80' prefix will be elected for a
+            node. e.g. 'face:b00c:0:0:1234::/80'. Default: 128.
+        :param assume_drained Default: False.
+        :param config_store_filepath Default:
+            /tmp/aq_persistent_config_store.bin
+        :param decision_debounce_max_ms: Knobs to control how often to run
+            Decision. On receipt of first even debounce is created with MIN
+            time which grows exponentially up to max if there are more events
+            before debounce is executed. This helps us to react to single
+            network failures quickly enough (with min duration) while avoid
+            high CPU utilization under heavy network churn. Default: 250.
+        :param decision_debounce_min_ms: Knobs to control how often to run
+            Decision. On receipt of first even debounce is created with MIN time
+            which grows exponentially up to max if there are more events before
+            debounce is executed.  This helps us to react to single network
+            failures quickly enough (with min duration) while avoid high CPU
+            utilization under heavy network churn.  Default: 10.
+        :param decision_rep_port Default: 60004.
+        :param domain: Name of domain this node is part of. OpenR will 'only'
+            form adjacencies to OpenR instances within it's own domain.  This
+            option becomes very useful if you want to run OpenR on two nodes
+            adjacent to each other but belonging to different domains, e.g.
+            Data Center and Wide Area Network.  Usually it should depict the
+            Network. Default: openr.
+        :param dryrun: OpenR will not try to program routes in it's default
+            configuration. You should explicitly set this option to false to
+            proceed with route programming. Default: False.
+        :param enable_subnet_validation: OpenR supports subnet validation to
+            avoid mis-cabling of v4 addresses on different subnets on each end
+            of the link. Need to enable v4 and this flag at the same time to
+            turn on validation. Default: True.
+        :param enable_fib_sync Default: False.
+        :param enable_health_checker: OpenR can measure network health
+            internally by pinging other nodes in the network and exports this
+            information as counters or via breeze APIs. By default health
+            checker is disabled. The expectation is that each node must have at
+            least one v6 loopback addressed announced into the network for the
+            reachability check. Default: False.
+        :param enable_legacy_flooding Default: True.
+        :param enable_lfa: With this option, additional Loop-Free Alternate
+            (LFA) routes can be computed, per RFC 5286, for fast failure
+            recovery.  Under the failure of all primary nexthops for a prefix,
+            because of link failure, next best precomputed LFA will be used
+            without need of an SPF run. Default: False.
+        :param enable_netlink_fib_handler: Knob to enable/disable default
+            implementation of 'FibService' that comes along with OpenR for
+            Linux platform. If you want to run your own FIB service then
+            disable this option. Default: True.
+        :param enable_netlink_system_handler: Knob to enable/disable default
+            implementation of 'SystemService' and 'PlatformPublisher' that
+            comes along with OpenR for Linux platform. If you want to run your
+            own SystemService then disable this option. Default: True.
+        :param enable_old_decision_module Default: False.
+        :param enable_perf_measurement: Experimental feature to measure
+            convergence performance. Performance information can be viewed via
+            breeze API 'breeze perf fib'. Default: True.
+        :param enable_prefix_alloc: Enable prefix allocator to elect and assign
+            a unique prefix for the node. You will need to specify other
+            configuration parameters below. Default: False.
+        :param enable_rtt_metric: Default mechanism for cost of a link is '1'
+            and hence cost of path is hop count. With this option you can ask
+            OpenR to compute and use RTT of a link as a metric value.  You
+            should only use this for networks where links have significant
+            delay, on the order of a couple of milliseconds.  Using this for
+            point-to-point links will cause lot of churn in metric updates as
+            measured RTT will fluctuate a lot because of packet processing
+            overhead. RTT is measured at application level and hence the
+            fluctuation for point-to-point links. Default: True.
+        :param enable_secure_thrift_server: Flag to enable TLS for our thrift
+            server. Disable this for plaintext thrift. Default: False.
+        :param enable_segment_routing: Experinmental and partially implemented
+            segment routing feature. As of now it only elects node/adjacency
+            labels. In future we will extend it to compute and program FIB
+            routes. Default: False.
+        :param enable_spark Default: True.
+        :param enable_v4: OpenR supports v4 as well but it needs to be turned
+            on explicitly. It is expected that each interface will have v4
+            address configured for link local transport and v4/v6 topologies
+            are congruent. Default: False.
+        :param enable_watchdog Default: True.
+        :param fib_handler_port: TCP port on which 'FibService' will be
+            listening. Default: 60100.
+        :param fib_rep_port Default: 60009.
+        :param health_checker_ping_interval_s: Configure ping interval of the
+            health checker. The below option configures it to ping all other
+            nodes every 3 seconds. Default: 3.
+        :param health_checker_rep_port Default: 60012.
+        :param ifname_prefix: Interface prefixes to perform neighbor discovery
+            on. All interfaces whose names start with these are used for
+            neighbor discovery. Default: ""
+        :param iface_regex_exclude Default:"".
+        :param iface_regex_include Default: "".
+        :param ip_tos: Set type of service (TOS) value with which every control
+            plane packet from Open/R will be marked with. This marking can be
+            used to prioritize control plane traffic (as compared to data
+            plane) so that congestion in network doesn't affect operations of
+            Open/R. Default: 192
+        :param key_prefix_filters: This comma separated string is used to set
+            the key prefixes when key prefix filter is enabled (See
+            SET_LEAF_NODE).  It is also set when requesting KEY_DUMP from peer
+            to request keys that match one of these prefixes. Default: "".
+        :param kvstore_flood_msg_per_sec Default: 0.
+        :param kvstore_flood_msg_burst_size Default: 0.
+        :param kvstore_flood_msg_per_sec Default: 0.
+        :param kvstore_ttl_decrement_ms Default: 1.
+        :param kvstore_zmq_hwm: Set buffering size for KvStore socket
+            communication. Updates to neighbor node during flooding can be
+            buffered upto this number. For larger networks where burst of
+            updates can be high having high value makes sense. For smaller
+            networks where burst of updates are low, having low value makes
+            more sense. Default: 65536.
+        :param link_flap_initial_backoff_ms Default: 1000.
+        :param link_flap_max_backoff_ms Default: 60000.
+        :param link_monitor_cmd_port Default: 60006.
+        :param loopback_iface: Indicates loopback address to which auto elected
+            prefix will be assigned if enabled. Default: "lo".
+        :param memory_limit_mb: Enforce upper limit on amount of memory in
+            mega-bytes that open/r process can use. Above this limit watchdog
+            thread will trigger crash. Service can be auto-restarted via system
+            or some kind of service manager. This is very useful to guarantee
+            protocol doesn't cause trouble to other services on device where it
+            runs and takes care of slow memory leak kind of issues. Default:
+            300.
+        :param minloglevel: Log messages at or above this level. Again, the
+            numbers of severity levels INFO, WARNING, ERROR, and FATAL are 0,
+            1, 2, and 3, respectively. Default: 0.
+        :param node_name: Name of the OpenR node. Cruical setting if you run
+            multiple nodes. Default: "".
+        :param override_loopback_addr: Whenever new address is elected for a
+            node, before assigning it to interface all previously allocated
+            prefixes or other global prefixes will be overridden with the new
+            one. Use it with care! Default: False.
+        :param prefix_manager_cmd_port Default: 60011.
+        :param prefixes: Static list of comma separate prefixes to announce
+            from the current node. Can't be changed while running. Default: "".
+        :param redistribute_ifaces: Comma separated list of interface names
+            whose '/32' (for v4) and '/128' (for v6) should be announced. OpenR
+            will monitor address add/remove activity on this interface and
+            announce it to rest of the network. Default: "lo1".
+        :param seed_prefix: In order to elect a prefix for the node a super
+            prefix to elect from is required. This is only applicable when
+            'ENABLE_PREFIX_ALLOC' is set to true. Default: "".
+        :param set_leaf_node: Sometimes a node maybe a leaf node and have only
+            one path in to network. This node does not require to keep track of
+            the entire topology. In this case, it may be useful to optimize
+            memory by reducing the amount of key/vals tracked by the node.
+            Setting this flag enables key prefix filters defined by
+            KEY_PREFIX_FILTERS. A node only tracks keys in kvstore that matches
+            one of the prefixes in KEY_PREFIX_FILTERS. Default: False.
+        :param set_loopback_address: If set to true along with
+            'ENABLE_PREFIX_ALLOC' then second valid IP address of the block
+            will be assigned onto 'LOOPBACK_IFACE' interface. e.g. in this case
+            'face:b00c:0:0:1234::1/80' will be assigned on 'lo' interface.
+            Default: False.
+        :param spark_fastinit_keepalive_time_ms: When interface is detected UP,
+            OpenR can perform fast initial neighbor discovery as opposed to
+            slower keep alive packets. Default value is 100 which means
+            neighbor will be discovered within 200ms on a link. Default: 100.
+        :param spark_hold_time_s: Hold time indicating time in seconds from
+            it's last hello after which neighbor will be declared as down.
+            Default: 30.
+        :param spark_keepalive_time_s: How often to send spark hello messages
+            to neighbors. Default: 3.
+        :param static_prefix_alloc Default: False.
+        :param tls_acceptable_peers: A comma separated list of strings. Strings
+            are x509 common names to accept SSL connections from. Default: ""
+        :param tls_ecc_curve_name: If we are running an SSL thrift server, this
+            option specifies the eccCurveName for the associated
+            wangle::SSLContextConfig. Default: "prime256v1".
+        :param tls_ticket_seed_path: If we are running an SSL thrift server,
+            this option specifies the TLS ticket seed file path to use for
+            client session resumption. Default: "".
+        :param x509_ca_path: If we are running an SSL thrift server, this
+            option specifies the certificate authority path for verifying
+            peers. Default: "".
+        :param x509_cert_path: If we are running an SSL thrift server, this
+            option specifies the certificate path for the associated
+            wangle::SSLContextConfig. Default: "".
+        :param x509_key_path: If we are running an SSL thrift server, this
+            option specifies the key path for the associated
+            wangle::SSLContextConfig. Default: "".
+        :param logbufsecs Default: 0
+        :param log_dir: Directory to store log files at. The folder must exist.
+            Default: /var/log.
+        :param max_log_size Default: 1.
+        :param v: Show all verbose 'VLOG(m)' messages for m less or equal the
+            value of this flag. Use higher value for more verbose logging.
+            Default: 1.
+        """
         super(OpenrDaemon, self).set_defaults(defaults)
 
     def _cfg_options(self):

--- a/ipmininet/router/config/templates/openr.mako
+++ b/ipmininet/router/config/templates/openr.mako
@@ -1,0 +1,75 @@
+<%
+    # Read value from node or use default value
+    def getConfig(key, default):
+        if key in node['openr']:
+            val = node['openr'][key]
+        else:
+            val = default
+        return "--{k}={v}".format(k=key, v=val)
+%>\
+${getConfig("alloc_prefix_len", 128)} \
+${getConfig("assume_drained", False)} \
+${getConfig("config_store_filepath", "/tmp/aq_persistent_config_store.bin")} \
+${getConfig("decision_debounce_max_ms", 250)} \
+${getConfig("decision_debounce_min_ms", 10)} \
+${getConfig("decision_rep_port", 60004)} \
+${getConfig("domain","openr")} \
+${getConfig("dryrun", False)} \
+${getConfig("enable_subnet_validation", True)} \
+${getConfig("enable_fib_sync", False)} \
+${getConfig("enable_health_checker", False)} \
+${getConfig("enable_legacy_flooding", True)} \
+${getConfig("enable_lfa", False)} \
+${getConfig("enable_netlink_fib_handler", True)} \
+${getConfig("enable_netlink_system_handler", True)} \
+${getConfig("enable_old_decision_module", False)} \
+${getConfig("enable_perf_measurement", True)} \
+${getConfig("enable_prefix_alloc", False)} \
+${getConfig("enable_rtt_metric", True)} \
+${getConfig("enable_secure_thrift_server", False)} \
+${getConfig("enable_segment_routing", False)} \
+${getConfig("enable_spark", True)} \
+${getConfig("enable_v4", False)} \
+${getConfig("enable_watchdog", True)} \
+${getConfig("fib_handler_port", 60100)} \
+${getConfig("fib_rep_port", 60009)} \
+${getConfig("health_checker_ping_interval_s", 3)} \
+${getConfig("health_checker_rep_port", 60012)} \
+${getConfig("ifname_prefix", "")} \
+${getConfig("iface_regex_exclude", "")} \
+${getConfig("iface_regex_include", "")} \
+${getConfig("ip_tos", 192)} \
+${getConfig("key_prefix_filters", "")} \
+${getConfig("kvstore_flood_msg_per_sec", 0)} \
+${getConfig("kvstore_flood_msg_burst_size", 0)} \
+${getConfig("kvstore_flood_msg_per_sec", 0)} \
+${getConfig("kvstore_ttl_decrement_ms", 1)} \
+${getConfig("kvstore_zmq_hwm", 65536)} \
+${getConfig("link_flap_initial_backoff_ms", 1000)} \
+${getConfig("link_flap_max_backoff_ms", 60000)} \
+${getConfig("link_monitor_cmd_port", 60006)} \
+${getConfig("loopback_iface", "lo")} \
+${getConfig("memory_limit_mb", 300)} \
+${getConfig("minloglevel", 0)} \
+${getConfig("node_name", "")} \
+${getConfig("override_loopback_addr", False)} \
+${getConfig("prefix_manager_cmd_port", 60011)} \
+${getConfig("prefixes", "")} \
+${getConfig("redistribute_ifaces", "lo1")} \
+${getConfig("seed_prefix", "")} \
+${getConfig("set_leaf_node", False)} \
+${getConfig("set_loopback_address", False)} \
+${getConfig("spark_fastinit_keepalive_time_ms", 100)} \
+${getConfig("spark_hold_time_s", 30)} \
+${getConfig("spark_keepalive_time_s", 3)} \
+${getConfig("static_prefix_alloc", False)} \
+${getConfig("tls_acceptable_peers", "")} \
+${getConfig("tls_ecc_curve_name", "prime256v1")} \
+${getConfig("tls_ticket_seed_path", "")} \
+${getConfig("x509_ca_path", "")} \
+${getConfig("x509_cert_path", "")} \
+${getConfig("x509_key_path", "")} \
+${getConfig("logbufsecs", 0)} \
+${getConfig("log_dir", "/var/log")} \
+${getConfig("max_log_size", 1)} \
+${getConfig("v", 1)} \


### PR DESCRIPTION
The PR adds support for facebooks open source routing platform [OpenR](https://github.com/facebook/openr). It's  traditional link state routing protocol with a modular architecture.

Since the build script for OpenR is currently broken the OpenR daemon can be built as described in https://github.com/facebook/openr/pull/41.