### PR TITLE
Installation script

### DIFF
--- a/util/build_vm.sh
+++ b/util/build_vm.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# This script is intended to install Mininet and IPMininet into
+# a brand-new Ubuntu virtual machine,
+# to create a fully usable "tutorial" VM.
+set -e
+
+export LC_ALL=C
+
+MN_VERSION="master"
+MN_INSTALL_SCRIPT_REMOTE="https://raw.githubusercontent.com/mininet/mininet/${MN_VERSION}/util/vm/install-mininet-vm.sh"
+DEPS="python \
+      python-pip \
+      python3 \
+      python3-pip
+      git"
+
+# Upgrade system and install dependencies
+sudo apt update -yq && sudo apt upgrade -yq
+sudo apt install -yq ${DEPS}
+
+# Set mininet-vm in hosts since mininet install will change the hostname
+sudo sed -i -e 's/^\(127\.0\.1\.1\).*/\1\tmininet-vm/' /etc/hosts
+
+# Install mininet
+pushd $HOME
+source <(curl -sL ${MN_INSTALL_SCRIPT_REMOTE})
+sudo pip2 install mininet/
+
+# Install ipmininet
+git clone https://github.com/cnp3/ipmininet.git
+pushd ipmininet
+sudo python util/install.py -ia
+popd
+popd
+
+# Fix setuptools version issue
+sudo pip2 install --upgrade pip
+sudo apt-get remove -y python-pip
+sudo pip2 install --upgrade setuptools

--- a/util/install.py
+++ b/util/install.py
@@ -1,0 +1,132 @@
+import argparse
+import os
+import sys
+
+from utils import supported_distributions, identify_distribution, sh
+
+MininetVersion = "master"
+QuaggaVersion = "1.2.4"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Install IPMininet with its dependencies")
+    parser.add_argument("-o", "--output-dir", help="Path to the directory that will store the dependencies",
+                        default=os.environ["HOME"])
+    parser.add_argument("-i", "--install-ipmininet", help="Install IPMininet", action="store_true")
+    parser.add_argument("-m", "--install-mininet", help="Install the last version of mininet and its dependencies",
+                        action="store_true")
+    parser.add_argument("-a", "--all", help="Install all daemons", action="store_true")
+    parser.add_argument("-q", "--install-quagga", help="Install Quagga (version %s) daemons" % QuaggaVersion,
+                        action="store_true")
+    parser.add_argument("-r", "--install-radvd", help="Install the RADVD daemon",
+                        action="store_true")
+    parser.add_argument("-s", "--install-sshd", help="Install the OpenSSH server", action="store_true")
+    return parser.parse_args()
+
+
+def install_mininet():
+    dist.install("git")
+
+    if dist.NAME == "Fedora":
+        mininet_opts = "-fnp"
+        dist.install("openvswitch", "openvswitch-devel", "openvswitch-test")
+        sh("systemctl enable openvswitch")
+        sh("systemctl start openvswitch")
+    else:
+        mininet_opts = "-a"
+
+    sh("git clone https://github.com/mininet/mininet.git",
+       "git checkout %s" % MininetVersion,
+       "mininet/util/install.sh %s -s ." % mininet_opts,
+       "pip2 -q install mininet/",
+       cwd=args.output_dir)
+
+
+def install_quagga():
+    dist.install("autoconf", "automake", "libtool", "make", "gcc", "gawk", "pkg-config")
+
+    if dist.NAME == "Ubuntu" or dist.NAME == "Debian":
+        dist.install("libreadline-dev", "libc-ares-dev")
+    elif dist.NAME == "Fedora":
+        dist.install("readline-devel", "c-ares-devel")
+
+    quagga_src = os.path.join(args.output_dir, "quagga-%s" % QuaggaVersion)
+    quagga_tar = quagga_src + ".tar.gz"
+    sh("wget http://download.savannah.gnu.org/releases/quagga/quagga-%s.tar.gz" % QuaggaVersion,
+       "tar -zxvf '%s'" % quagga_tar,
+       cwd=args.output_dir)
+
+    quagga_install = os.path.join(args.output_dir, "quagga")
+    sh("./configure '--prefix=%s'" % quagga_install,
+       "make",
+       "make install",
+       cwd=quagga_src)
+
+    sh("rm -r '%s' '%s'" % (quagga_src, quagga_tar))
+
+    sh("groupadd quagga", may_fail=True)
+    sh("usermod -a -G quagga root", may_fail=True)
+
+    for root, _, files in os.walk(os.path.join(quagga_install, "sbin")):
+        for f in files:
+            link = os.path.join("/usr/sbin", os.path.basename(f))
+            if os.path.exists(link):
+                os.remove(link)
+            os.symlink(os.path.join(root, f), link)
+        break
+    for root, _, files in os.walk(os.path.join(quagga_install, "bin")):
+        for f in files:
+            link = os.path.join("/usr/bin", os.path.basename(f))
+            if os.path.exists(link):
+                os.remove(link)
+            os.symlink(os.path.join(root, f), link)
+        break
+
+
+args = parse_args()
+args.output_dir = os.path.normpath(os.path.abspath(args.output_dir))
+
+if os.getuid() != 0:
+    print("This program must be run as root")
+    sys.exit(1)
+
+# Identify the distribution
+
+dist = identify_distribution()
+if dist is None:
+    print("The installation script only supports %s" % ", ".join([d.NAME for d in supported_distributions()]))
+    sys.exit(1)
+dist.update()
+
+# Install dependencies
+
+dist.install("python-pip")
+
+if args.install_mininet:
+    install_mininet()
+
+if args.all or args.install_quagga:
+    install_quagga()
+
+if args.all or args.install_radvd:
+    dist.install("radvd")
+
+if args.all or args.install_sshd:
+    dist.install("openssh-server")
+
+# Install IPMininet
+
+if args.install_ipmininet:
+    ipmininet_folder = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sh("pip2 -q install %s/" % ipmininet_folder)
+
+
+# Install test dependencies
+
+dist.install("bridge-utils", "traceroute")
+if dist.NAME == "Fedora":
+    dist.install("nc")
+else:
+    dist.install("netcat-openbsd")
+
+sh("pip2 -q install pytest")

--- a/util/utils.py
+++ b/util/utils.py
@@ -1,0 +1,82 @@
+import abc
+import os
+import shlex
+import subprocess
+import sys
+
+
+def sh(*cmds, **kwargs):
+    may_fail = kwargs.pop("may_fail", False)
+    env = kwargs.pop("env", os.environ)
+    env["LC_ALL"] = "C"
+
+    for cmd in cmds:
+        print("\n*** " + cmd)
+        p = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env, **kwargs)
+
+        while p.poll() is None:
+            out = p.stdout.readline()
+            if out != '':
+                sys.stdout.write(out)
+
+        out = p.stdout.read()
+        if out != '':
+            sys.stdout.write(out)
+
+        if p.poll() != 0:
+            if not may_fail:
+                sys.exit(1)
+            return False
+    return True
+
+
+class Distribution(object):
+    __metaclass__ = abc.ABCMeta
+
+    NAME = None
+    INSTALL_CMD = None
+    UPDATE_CMD = None
+
+    def install(self, *packages):
+        sh(self.INSTALL_CMD + " " + " ".join(packages))
+
+    def update(self):
+        sh(self.UPDATE_CMD)
+
+
+class Ubuntu(Distribution):
+    NAME = "Ubuntu"
+    INSTALL_CMD = "apt-get -y -q install"
+    UPDATE_CMD = "apt-get update"
+
+
+class Debian(Distribution):
+    NAME = "Debian"
+    INSTALL_CMD = "apt-get -y -q install"
+    UPDATE_CMD = "apt-get update"
+
+
+class Fedora(Distribution):
+    NAME = "Fedora"
+    INSTALL_CMD = "yum -y install"
+    UPDATE_CMD = "true"
+
+
+def supported_distributions():
+    return Distribution.__subclasses__()
+
+
+def identify_distribution():
+    try:
+        subprocess.check_call(shlex.split("grep Ubuntu /etc/lsb-release"))
+        return Ubuntu()
+    except subprocess.CalledProcessError:
+        pass
+
+    if os.path.exists("/etc/debian_version"):
+        return Debian()
+
+    if os.path.exists("/etc/fedora-release"):
+        return Fedora()
+
+    return None


### PR DESCRIPTION
This adds an installation script in Python.
It will be more readable than a bash script if it grows in the future and it is easier to support multiple discributions.
For the moment, Ubuntu, Debian and Fedora work with this script.

There is also a provisioning script for an Ubuntu 16.04 VM adapted from PR #24 to use the installation script.

A [vagrant box](https://app.vagrantup.com/ipmininet/boxes/ubuntu-16.04) was generated.