### PR TITLE
[OpenR] Enhance the install script for OpenR

### DIFF
--- a/util/build_vm.sh
+++ b/util/build_vm.sh
@@ -30,7 +30,7 @@ sudo pip2 install mininet/
 # Install ipmininet
 git clone https://github.com/cnp3/ipmininet.git
 pushd ipmininet
-sudo python util/install.py -ia
+sudo python util/install.py -iaf
 popd
 popd
 

--- a/util/build_vm.sh
+++ b/util/build_vm.sh
@@ -12,7 +12,7 @@ MN_INSTALL_SCRIPT_REMOTE="https://raw.githubusercontent.com/mininet/mininet/${MN
 DEPS="python \
       python-pip \
       python3 \
-      python3-pip
+      python3-pip \
       git"
 
 # Upgrade system and install dependencies

--- a/util/install.py
+++ b/util/install.py
@@ -142,9 +142,7 @@ def enable_ipv6():
         data = f.read()
         f.seek(0)
         # Comment out lines
-        f.write(re.sub(r'^.*disable_ipv6.*$', r'#\g<0>',
-                       "foo_disable_ipv6_bar = 1",
-                       data))
+        f.write(re.sub(r'\n(.*disable_ipv6.*)', r'\n#\g<1>', data))
         f.truncate()
     sh("sysctl -p")
 


### PR DESCRIPTION
Enhance the install script to build and install OpenR. To run OpenR in
ipmininet "routers" there are two main requirements for the host system:

1. OpenR and its dependencies are installed
2. IPv6 is enabled (disabled by the mininet install script)

The OpenR build requires several steps:

1. Clone OpenR
2. Generate the build script from python scripts
3. Make the generated build script executable
4. Build and install OpenR using the build script

IPv6 support is re-enabled by changing/ removing the kernel parameters
in `/etc/default/grub` and `/etc/sysctl.conf`.