### PR TITLE
[fix] Return host in IPNet addHost

### DIFF
--- a/ipmininet/ipnet.py
+++ b/ipmininet/ipnet.py
@@ -157,7 +157,7 @@ class IPNet(Mininet):
            IPNet."""
         if 'ip' not in params:
             params['ip'] = None
-        super(IPNet, self).addHost(name, **params)
+        return super(IPNet, self).addHost(name, **params)
 
     def node_for_ip(self, ip):
         """Return the node owning a given IP address


### PR DESCRIPTION
The addHost method of Mininet returns the host instance. Since we call
the method from the super class we should return the result.