### PR TITLE
Fix handling of networks with partial dual stack

### DIFF
--- a/ipmininet/router/config/radvd.py
+++ b/ipmininet/router/config/radvd.py
@@ -78,8 +78,10 @@ class RADVD(Daemon):
     def cleanup(self):
         try:
             with open(self._file('pid'), 'r') as f:
-                pid = int(f.read())
-                self._node._processes.call('kill -9 %d ' % pid)
+                for line in f:
+                    if len(line) > 1:
+                        pid = int(line[:-1])
+                        self._node._processes.call('kill -9 %d ' % pid)
         except (IOError, OSError):
             pass
         super(RADVD, self).cleanup()

--- a/ipmininet/router/config/templates/ospf6d.mako
+++ b/ipmininet/router/config/templates/ospf6d.mako
@@ -27,7 +27,7 @@ interface ${intf.name}
 % endfor
 
 router ospf6
-  router-id ${node.ospf6d.routerid}
+  ospf6 router-id ${node.ospf6d.routerid}
   % for r in node.ospf6d.redistribute:
   redistribute ${r.subtype}
   % endfor

--- a/ipmininet/router/config/templates/ospfd.mako
+++ b/ipmininet/router/config/templates/ospfd.mako
@@ -24,7 +24,7 @@ interface ${intf.name}
 % endfor
 
 router ospf
-  router-id ${node.ospfd.routerid}
+  ospf router-id ${node.ospfd.routerid}
   % for r in node.ospfd.redistribute:
   redistribute ${r.subtype} metric-type ${r.metric_type} metric ${r.metric}
   % endfor


### PR DESCRIPTION
This prevents the allocation of an IPv4/IPv6 to hosts if no other
L3 node on the broadcast domain enables IPv4/IPv6.