### PR TITLE
Improve RADVD configuration

### DIFF
--- a/ipmininet/examples/router_adv_network.py
+++ b/ipmininet/examples/router_adv_network.py
@@ -2,7 +2,7 @@
 addresses and to advertise DNS server's addresses"""
 
 from ipmininet.iptopo import IPTopo
-from ipmininet.router.config import RouterConfig, RADVD, AdvPrefix, AdvRDNSS
+from ipmininet.router.config import RouterConfig, RADVD, AdvConnectedPrefix, AdvRDNSS
 
 
 class RouterAdvNet(IPTopo):
@@ -25,8 +25,8 @@ class RouterAdvNet(IPTopo):
         dns = self.addHost('dns')
         self.addLink(r, h, params1={
             "ip": ("2001:1341::1/64", "2001:2141::1/64"),
-            "ra": [AdvPrefix("2001:1341::/64"), AdvPrefix("2001:2141::/64")],
-            "rdnss": [AdvRDNSS("2001:89ab::d"), AdvRDNSS("2001:cdef::d")]})
+            "ra": [AdvConnectedPrefix()],
+            "rdnss": [AdvRDNSS(dns)]})
         self.addLink(r, dns,
                      params1={"ip": ("2001:89ab::1/64", "2001:cdef::1/64")},
                      params2={"ip": ("2001:89ab::d/64", "2001:cdef::d/64")})
@@ -35,4 +35,3 @@ class RouterAdvNet(IPTopo):
 
     def addRouter_v6(self, name, **kwargs):
         return self.addRouter(name, config=RouterConfig, use_v4=False, use_v6=True, **kwargs)
-

--- a/ipmininet/router/config/__init__.py
+++ b/ipmininet/router/config/__init__.py
@@ -5,7 +5,7 @@ from .zebra import Zebra
 from .ospf import OSPF, OSPFArea
 from .ospf6 import OSPF6
 from .bgp import BGP, AS, iBGPFullMesh, bgp_peering, bgp_fullmesh, ebgp_session
-from .radvd import RADVD, AdvPrefix, AdvRDNSS
+from .radvd import RADVD, AdvPrefix, AdvRDNSS, AdvConnectedPrefix
 from .iptables import IPTables, IP6Tables
 from .sshd import SSHd
 from .pimd import PIMD
@@ -15,4 +15,4 @@ from .openr import Openr
 __all__ = ['BasicRouterConfig', 'Zebra', 'OSPF', 'OSPF6', 'OSPFArea', 'BGP',
            'AS', 'iBGPFullMesh', 'bgp_peering', 'RouterConfig', 'bgp_fullmesh',
            'ebgp_session', 'IPTables', 'IP6Tables', 'SSHd', 'RADVD',
-           'AdvPrefix', 'AdvRDNSS', 'PIMD', 'OpenrDaemon', 'Openr']
+           'AdvPrefix', 'AdvConnectedPrefix', 'AdvRDNSS', 'PIMD', 'OpenrDaemon', 'Openr']

--- a/ipmininet/router/config/radvd.py
+++ b/ipmininet/router/config/radvd.py
@@ -1,6 +1,12 @@
+from builtins import str
+
+from ipaddress import ip_address
+
+from ipmininet.utils import find_node
+from ipmininet.utils import realIntfList
 from .base import Daemon
 from .utils import ConfigDict
-from ipmininet.utils import realIntfList
+from ipmininet.utils import is_container
 
 RA_DEFAULT_VALID = 86400
 RA_DEFAULT_PREF = 14400
@@ -8,32 +14,50 @@ DEFAULT_ADV_RDNSS_LIFETIME = 25
 
 
 class AdvPrefix(ConfigDict):
-    """The class representing an advertised prefix in a Router Advertisement"""
+    """The class representing advertised prefixes in a Router Advertisement"""
 
-    def __init__(self, prefix, valid_lifetime=RA_DEFAULT_VALID,
+    def __init__(self, prefix=(), valid_lifetime=RA_DEFAULT_VALID,
                  preferred_lifetime=RA_DEFAULT_PREF):
-        """:param prefix: the IPv6 prefix to advertise
+        """:param prefix: the list of IPv6 prefixes to advertise
            :param valid_lifetime: corresponds to the AdvValidLifetime
                                   in radvd.conf(5) for this prefix
            :param preferred_lifetime: corresponds to the AdvPreferredLifetime
                                       in radvd.conf(5) for this prefix"""
         super(AdvPrefix, self).__init__()
-        self["prefix"] = prefix
+        self["prefixes"] = list(prefix) if is_container(prefix) else [prefix]
         self["valid_lifetime"] = valid_lifetime
         self["preferred_lifetime"] = preferred_lifetime
+
+
+class AdvConnectedPrefix(AdvPrefix):
+    """This class forces the advertisement of all prefixes on the interface"""
+
+    def __init__(self, valid_lifetime=RA_DEFAULT_VALID,
+                 preferred_lifetime=RA_DEFAULT_PREF):
+        """:param valid_lifetime: corresponds to the AdvValidLifetime
+                                  in radvd.conf(5) for this prefix
+           :param preferred_lifetime: corresponds to the AdvPreferredLifetime
+                                      in radvd.conf(5) for this prefix"""
+        super(AdvConnectedPrefix, self).__init__(valid_lifetime=valid_lifetime,
+                                                 preferred_lifetime=preferred_lifetime)
 
 
 class AdvRDNSS(ConfigDict):
     """The class representing an advertised DNS server in a
     Router Advertisement"""
 
-    def __init__(self, ip, max_lifetime=DEFAULT_ADV_RDNSS_LIFETIME):
-        """:param ip: the IPv6 address of the DNS server
+    def __init__(self, node, max_lifetime=DEFAULT_ADV_RDNSS_LIFETIME):
+        """:param node: Either the IPv6 address of the DNS server or the node name
            :param max_lifetime: corresponds to the AdvValidLifetime
                                 in radvd.conf(5) for this dns server address"""
         super(AdvRDNSS, self).__init__()
-        self["ip"] = ip
+        self["node"] = node
         self["max_lifetime"] = max_lifetime
+        try:
+            ip_address(str(node))
+            self["ips"] = [node]
+        except ValueError:
+            pass
 
 
 class RADVD(Daemon):
@@ -53,7 +77,28 @@ class RADVD(Daemon):
                                      rdnss_list=itf.rdnss_list)
                           for itf in realIntfList(self._node)
                           if itf.ra_prefixes)
+        # Fill AdvConnectedPrefix prefixes
+        self._fill_connected_prefixes()
+        # Fill AdvRDNSS IP addresses
+        self._fill_rdnss_addresses()
         return cfg
+
+    def _fill_connected_prefixes(self):
+        for itf in realIntfList(self._node):
+            for ra_prefix in itf.ra_prefixes:
+                if isinstance(ra_prefix, AdvConnectedPrefix):
+                    for ip in itf.ip6s(exclude_lls=True):
+                        ra_prefix.prefixes.append(ip.network.with_prefixlen)
+
+    def _fill_rdnss_addresses(self):
+        for itf in realIntfList(self._node):
+            for rdnss in itf.rdnss_list:
+                if rdnss.ips is None:
+                    rdnss.ips = []
+                    dns = find_node(self._node, rdnss.node).node
+                    for dns_itf in realIntfList(dns):
+                        for ip in dns_itf.ip6s(exclude_lls=True):
+                            rdnss.ips.append(ip.ip.compressed)
 
     def set_defaults(self, defaults):
         """

--- a/ipmininet/router/config/templates/radvd.mako
+++ b/ipmininet/router/config/templates/radvd.mako
@@ -5,22 +5,26 @@
         IgnoreIfMissing on;
         AdvSendAdvert on;
         MaxRtrAdvInterval 15;
-        % for prefix in itf.ra_prefixes:
-        prefix ${prefix.prefix}
+        % for adv_prefixes in itf.ra_prefixes:
+            % for prefix in adv_prefixes.prefixes:
+        prefix ${prefix}
         {
-             AdvOnLink on;
-             AdvAutonomous on;
-             AdvValidLifetime ${prefix.valid_lifetime};
-             AdvPreferredLifetime ${prefix.preferred_lifetime};
+            AdvOnLink on;
+            AdvAutonomous on;
+            AdvValidLifetime ${adv_prefixes.valid_lifetime};
+            AdvPreferredLifetime ${adv_prefixes.preferred_lifetime};
         };
+            %endfor
         % endfor
         % for rdnss in itf.rdnss_list:
-             RDNSS ${rdnss.ip} {
-                 AdvRDNSSLifetime ${rdnss.max_lifetime}; # in seconds (0 means invalid)
-             };
-             DNSSL local {
-                 # list of dnssl specific options
-             };
+            % for ip in rdnss.ips:
+        RDNSS ${ip} {
+            AdvRDNSSLifetime ${rdnss.max_lifetime}; # in seconds (0 means invalid)
+        };
+        DNSSL local {
+            # list of dnssl specific options
+        };
+            % endfor
         % endfor
     };
 % endfor

--- a/ipmininet/tests/test_radv.py
+++ b/ipmininet/tests/test_radv.py
@@ -47,12 +47,12 @@ def test_radvd_example():
 @pytest.mark.parametrize("link_params,expected_cfg", [
     ({"params1": {"ra": [AdvPrefix("2001:1341::/64", valid_lifetime=2000, preferred_lifetime=1000)]}},
      ["        prefix 2001:1341::/64",
-      "             AdvValidLifetime 2000;",
-      "             AdvPreferredLifetime 1000;"]),
+      "            AdvValidLifetime 2000;",
+      "            AdvPreferredLifetime 1000;"]),
     ({"params1": {"ra": [AdvPrefix("2001:1341::/64")],
                   "rdnss": [AdvRDNSS("2001:89ab::d", max_lifetime=1000)]}},
-     ["             RDNSS 2001:89ab::d {",
-      "                 AdvRDNSSLifetime 1000; # in seconds (0 means invalid)"])
+     ["        RDNSS 2001:89ab::d {",
+      "            AdvRDNSSLifetime 1000; # in seconds (0 means invalid)"])
 ])
 def test_radvd_daemon_params(link_params, expected_cfg):
     try:

--- a/ipmininet/utils.py
+++ b/ipmininet/utils.py
@@ -109,3 +109,30 @@ def get_set(d, key, default):
     except KeyError:
         x = d[key] = default()
         return x
+
+
+def find_node(start, node_name):
+    """
+    :param start: The starting node of the search
+    :param node_name: The name of the node to find
+    :return: The interface of the node connected to start with node_name as name
+    """
+
+    if start.name == node_name:
+        return start
+
+    visited = set()
+    to_visit = realIntfList(start)
+    # Explore all interfaces recursively, until we find one
+    # connected to the node
+    while to_visit:
+        i = to_visit.pop()
+        if i in visited:
+            continue
+        visited.add(i)
+        for n in i.broadcast_domain.interfaces:
+            if n.node.name == node_name:
+                return n
+            elif L3Router.is_l3router_intf(n):
+                to_visit.extend(realIntfList(n.node))
+    return None


### PR DESCRIPTION
The RADVD configuration is improved to allow defining a RADVD daemon without fixing IP addresses.

This adds AdvConnectedPrefix() instead of needing explicitly to give all the addresses.
This enables AdvRDNSS() to take node names instead of the IP addresses.