### PR TITLE
Fix broadcast domain building

### DIFF
--- a/ipmininet/ipnet.py
+++ b/ipmininet/ipnet.py
@@ -385,9 +385,9 @@ class IPNet(Mininet):
                       if BroadcastDomain.is_domain_boundary(n)
                       for intf in realIntfList(n)}
         interfaces.update({r.intf('lo'): False for r in self.routers})
-        for intf, explored in interfaces.items():
+        for intf in interfaces.keys():
             # the interface already belongs to a broadcast domain
-            if explored:
+            if interfaces[intf]:
                 continue
             # create a new domain and explore the interface
             bd = BroadcastDomain(intf)


### PR DESCRIPTION
In Python2, the items() method returns a list and not an iterator.
Therefore, changing the values of the dictionary in the loop had no
effect and a broadcast domain for each interface was created.