### PR TITLE
Fix CLI behavior with switches

### DIFF
--- a/ipmininet/cli.py
+++ b/ipmininet/cli.py
@@ -115,13 +115,6 @@ class IPCLI(CLI):
                     v6_map[hop] = ip6
             ip_map = v4_map if len(v4_map) >= len(v6_map) else v6_map
 
-            if len(ip_map) < len(hops):
-                missing = [h for h in hops if h not in ip_map]
-                version = 'IPv4' if v4_support else 'IPv6'
-                lg.error('*** Nodes', missing, 'have no', version,
-                         'address! Cannot execute the command.\n')
-                return
-
             node.sendCmd(' '.join([ip_map.get(r, r) for r in rest]))
             self.waitForNode(node)
         else:

--- a/ipmininet/tests/test_cli.py
+++ b/ipmininet/tests/test_cli.py
@@ -91,6 +91,7 @@ def perm(*args):
     ("ping6pair", ["h1 --IPv6--> h2 ",
                    "h2 --IPv6--> h1 "]),
     ("h1 echo h4", ["10.2.0.3"]),
+    ("s2 echo h4", ["h4"]),
     ("h1", ["*** Enter a command for node: h1 <cmd>"]),
     ("invalid_command", ["*** Unknown command: invalid_command"])
 ])

--- a/ipmininet/utils.py
+++ b/ipmininet/utils.py
@@ -53,8 +53,15 @@ def realIntfList(n):
 def address_pair(n, use_v4=True, use_v6=True):
     """Returns a tuple (ip, ip6) with ip/ip6 being one of the IPv4/IPv6
        addresses of the node n"""
+    from .link import IPIntf  # Prevent circular imports
     v4 = v6 = None
     for itf in n.intfList():
+        # Mininet switches have a loopback interface
+        # declared as an Intf.
+        # This object does not have ips() or ip6s() methods.
+        if not isinstance(itf, IPIntf):
+            continue
+
         if use_v4 and v4 is None:
             itf.updateIP()
             v4 = next(itf.ips(), None)


### PR DESCRIPTION
Mininet Switches have a loopback interface intialized with a plain Intf
class and not the IPIntf class, Therefore it misses ips() and ip6s()
methods.
Moreover, the fact that switches do not have IP addresses, do not
have to prevent the user from running commands on them.