### PR TITLE
Fix use_v4 and use_v6 impact on address allocation

### DIFF
--- a/ipmininet/examples/simple_ospf_network.py
+++ b/ipmininet/examples/simple_ospf_network.py
@@ -38,8 +38,8 @@ Management Network (OOB)|       |              |        |          |            
         host number attached to that router, and Y the router name.
         """
         # Build backbone
-        r1, r2 = self.addRouter('r1'), self.addRouter('r2')
-        r3 = self.addRouter('r3')
+        r1, r2 = self.addRouter_v4('r1'), self.addRouter_v4('r2')
+        r3 = self.addRouter_v4('r3')
         self.addLink(r1, r2)
         self.addLink(r1, r3, igp_metric=5)
         self.addLink(r3, r2)
@@ -49,7 +49,7 @@ Management Network (OOB)|       |              |        |          |            
                              params2={'v4_width': 5})
 
         # Area 1.1.1.1 is delimited by an OSPFArea overlay
-        r4, r5 = self.addRouter('r4'), self.addRouter('r5')
+        r4, r5 = self.addRouter_v4('r4'), self.addRouter_v4('r5')
         self.addLink(r2, r5)
         self.addLink(r2, r4)
         self.addLink(r4, r5, igp_metric=10)
@@ -59,7 +59,7 @@ Management Network (OOB)|       |              |        |          |            
         self.addOSPFArea(routers=(r4, r5), area='1.1.1.1')
 
         # Area 2.2.2.2 is delimited by the igp_area parameter of addLink()
-        r6, r7 = self.addRouter('r6'), self.addRouter('r7')
+        r6, r7 = self.addRouter_v4('r6'), self.addRouter_v4('r7')
         self.addLink(r3, r6, igp_area='2.2.2.2')
         self.addLink(r3, r7, igp_area='2.2.2.2', igp_metric=5)
         self.addLink(r6, r7, igp_area='2.2.2.2')
@@ -74,3 +74,6 @@ Management Network (OOB)|       |              |        |          |            
             self.addLink(s1, r, igp_passive=True)
 
         super().build(*args, **kwargs)
+
+    def addRouter_v4(self, name):
+        return self.addRouter(name, use_v4=True, use_v6=False)

--- a/ipmininet/tests/test_address_alllocation.py
+++ b/ipmininet/tests/test_address_alllocation.py
@@ -1,0 +1,45 @@
+import pytest
+
+from ipmininet.clean import cleanup
+from ipmininet.examples.simple_bgp_network import SimpleBGPTopo
+from ipmininet.examples.simple_ospf_network import SimpleOSPFNet
+from ipmininet.examples.simple_ospfv3_network import SimpleOSPFv3Net
+from ipmininet.ipnet import IPNet
+from ipmininet.tests import require_root
+
+
+@require_root
+@pytest.mark.parametrize("topo,use_v4,use_v6", [
+    (SimpleBGPTopo, True, True),
+    (SimpleBGPTopo, True, False),
+    (SimpleBGPTopo, False, True),
+    (SimpleOSPFNet, True, True),  # Routers with use_v6=False
+    (SimpleOSPFv3Net, True, True),  # Routers with use_v4=False
+])
+def test_v4_and_v6_only_network(topo, use_v4, use_v6):
+    try:
+        net = IPNet(topo=topo(), use_v4=use_v4, use_v6=use_v6)
+        net.start()
+
+        for n in net.routers + net.hosts:
+            for itf in n.intfList():
+                if itf.node.use_v4 and net.use_v4:
+                    assert len(list(itf.ips())) == itf.interface_width[0], \
+                        "Did not allocate enough IPv4 addresses on interface " \
+                        "{}".format(itf)
+                else:
+                    assert len(list(itf.ips())) == 0,\
+                        "Should not allocate IPv4 addresses on interface " \
+                        "{}".format(itf)
+                if itf.node.use_v6 and net.use_v6:
+                    assert len(list(itf.ip6s(exclude_lls=True))) == \
+                           itf.interface_width[1], \
+                        "Did not allocate enough IPv6 addresses on interface " \
+                        "{}".format(itf)
+                else:
+                    assert len(list(itf.ip6s(exclude_lls=True))) == 0, \
+                        "Should not allocate IPv6 addresses on interface " \
+                        "{}".format(itf)
+        net.stop()
+    finally:
+        cleanup()


### PR DESCRIPTION
No address of a given IP version is allocated on an address whose node is not supposed to use.
This also adds an automated test.

Fix #72 