### PR TITLE
Fix openr install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 recursive-include ipmininet/router/config/templates *
 recursive-include ipmininet/host/config/templates *
+include ipmininet/install/*.sh

--- a/ipmininet/install/build_openr-rc-20190419-11514.sh
+++ b/ipmininet/install/build_openr-rc-20190419-11514.sh
@@ -1,0 +1,281 @@
+#!/bin/bash
+
+set -exo pipefail
+### Install packages for Debian-based OS ###
+
+apt-get update && apt-get install -yq autoconf-archive bison build-essential cmake curl flex git gperf joe libboost-all-dev libcap-dev libdouble-conversion-dev libevent-dev libgflags-dev libgoogle-glog-dev libkrb5-dev libpcre3-dev libpthread-stubs0-dev libnuma-dev libsasl2-dev libsnappy-dev libsqlite3-dev libssl-dev libtool netcat-openbsd pkg-config sudo unzip wget python3-venv python-setuptools python3-setuptools python-pip ccache
+apt-get install -yq gcc-'5' g++-'5'
+update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-'5' 40 --slave /usr/bin/g++ g++ /usr/bin/g++-'5'
+update-alternatives --config gcc
+
+export CCACHE_DIR='/ccache' CC="ccache ${CC:-gcc}" CXX="ccache ${CXX:-g++}"
+### Diagnostics ###
+
+# Builder DebianSystemFBCodeBuilder(google/googletest:cmake_defines={u'BUILD_GTEST': u'ON', u'BUILD_SHARED_LIBS': u'OFF'}, gcc_version=u'5', facebook/zstd:git_hash=ShellQuoted(u'$(git describe --abbrev=0 --tags origin/master)'), hyperic/sigar:autoconf_options={u'CFLAGS': u'-fgnu89-inline'}, openr/build:cmake_defines={u'ADD_ROOT_TESTS': u'OFF'}, prefix=u'/usr/local', projects_dir=u'/usr/local/src', google/googletest:git_hash=u'release-1.8.1', wangle/wangle/build:cmake_defines={u'BUILD_TESTS': u'OFF'}, thom311/libnl:git_hash=u'libnl3_2_25', jedisct1/libsodium:git_hash=u'stable', ccache_dir=u'/ccache', make_parallelism=4, no1msd/mstch:git_hash=ShellQuoted(u'$(git describe --abbrev=0 --tags)'), zeromq/libzmq:git_hash=u'v4.2.5')
+hostname
+cat /etc/issue || echo no /etc/issue
+g++ --version || echo g++ not installed
+cmake --version || echo cmake not installed
+
+### Check out facebook/folly, workdir _build ###
+
+mkdir -p '/usr/local/src' && cd '/usr/local/src'
+if [[ ! -d '/usr/local/src'/'folly' ]]; then 
+	git clone https://github.com/'facebook/folly'
+fi
+mkdir -p '/usr/local/src'/'folly'/'_build' && cd '/usr/local/src'/'folly'/'_build'
+git checkout '3ceffd7d145be3c85a2aae39f99eb86ea730bdcc'
+
+### Build and install facebook/folly ###
+
+CXXFLAGS="$CXXFLAGS -fPIC" CFLAGS="$CFLAGS -fPIC" cmake -D'BUILD_SHARED_LIBS'='ON' '..'
+make -j '4' VERBOSE=1 
+sudo make install VERBOSE=1 
+sudo ldconfig
+
+### Check out jedisct1/libsodium, workdir . ###
+
+mkdir -p '/usr/local/src' && cd '/usr/local/src'
+if [[ ! -d '/usr/local/src'/'libsodium' ]]; then 
+	git clone https://github.com/'jedisct1/libsodium'
+fi
+mkdir -p '/usr/local/src'/'libsodium'/'.' && cd '/usr/local/src'/'libsodium'/'.'
+git checkout 'stable'
+
+### Build and install jedisct1/libsodium ###
+
+./autogen.sh
+LDFLAGS="$LDFLAGS" CFLAGS="$CFLAGS" CPPFLAGS="$CPPFLAGS" ./configure 
+make -j '4' VERBOSE=1 
+sudo make install VERBOSE=1 
+sudo ldconfig
+
+### Check out facebookincubator/fizz, workdir fizz/build ###
+
+mkdir -p '/usr/local/src' && cd '/usr/local/src'
+if [[ ! -d '/usr/local/src'/'fizz' ]]; then 
+	git clone https://github.com/'facebookincubator/fizz'
+fi
+mkdir -p '/usr/local/src'/'fizz'/'fizz/build' && cd '/usr/local/src'/'fizz'/'fizz/build'
+
+### Build and install fizz/fizz/build ###
+
+CXXFLAGS="$CXXFLAGS -fPIC" CFLAGS="$CFLAGS -fPIC" cmake -D'BUILD_SHARED_LIBS'='ON' '..'
+make -j '4' VERBOSE=1 
+sudo make install VERBOSE=1 
+sudo ldconfig
+
+### Check out google/googletest, workdir build ###
+
+mkdir -p '/usr/local/src' && cd '/usr/local/src'
+if [[ ! -d '/usr/local/src'/'googletest' ]]; then 
+	git clone https://github.com/'google/googletest'
+fi
+mkdir -p '/usr/local/src'/'googletest'/'build' && cd '/usr/local/src'/'googletest'/'build'
+git checkout 'release-1.8.1'
+
+### Build and install google/googletest ###
+
+CXXFLAGS="$CXXFLAGS -fPIC" CFLAGS="$CFLAGS -fPIC" cmake -D'BUILD_GTEST'='ON' -D'BUILD_SHARED_LIBS'='OFF' '..'
+make -j '4' VERBOSE=1 
+sudo make install VERBOSE=1 
+sudo ldconfig
+
+### Check out rsocket/rsocket-cpp, workdir rsocket ###
+
+mkdir -p '/usr/local/src' && cd '/usr/local/src'
+if [[ ! -d '/usr/local/src'/'rsocket-cpp' ]]; then 
+	git clone https://github.com/'rsocket/rsocket-cpp'
+fi
+mkdir -p '/usr/local/src'/'rsocket-cpp'/'rsocket' && cd '/usr/local/src'/'rsocket-cpp'/'rsocket'
+
+### Build and install rsocket-cpp/rsocket ###
+
+CXXFLAGS="$CXXFLAGS -fPIC" CFLAGS="$CFLAGS -fPIC" cmake -D'BUILD_SHARED_LIBS'='ON' '..'
+make -j '4' VERBOSE=1 
+sudo make install VERBOSE=1 
+sudo ldconfig
+
+### Check out facebook/wangle, workdir wangle/build ###
+
+mkdir -p '/usr/local/src' && cd '/usr/local/src'
+if [[ ! -d '/usr/local/src'/'wangle' ]]; then 
+	git clone https://github.com/'facebook/wangle'
+fi
+mkdir -p '/usr/local/src'/'wangle'/'wangle/build' && cd '/usr/local/src'/'wangle'/'wangle/build'
+git checkout 'f2f8e1996739df1fc8ab1e003a1bc6472bd5b9bd'
+
+### Build and install wangle/wangle/build ###
+
+CXXFLAGS="$CXXFLAGS -fPIC" CFLAGS="$CFLAGS -fPIC" cmake -D'BUILD_SHARED_LIBS'='ON' -D'BUILD_TESTS'='OFF' '..'
+make -j '4' VERBOSE=1 
+sudo make install VERBOSE=1 
+sudo ldconfig
+
+### Check out facebook/zstd, workdir . ###
+
+mkdir -p '/usr/local/src' && cd '/usr/local/src'
+if [[ ! -d '/usr/local/src'/'zstd' ]]; then 
+	git clone https://github.com/'facebook/zstd'
+fi
+mkdir -p '/usr/local/src'/'zstd'/'.' && cd '/usr/local/src'/'zstd'/'.'
+git checkout $(git describe --abbrev=0 --tags origin/master)
+
+### Build and install zstd ###
+
+make -j '4' VERBOSE=1 'PREFIX'='/usr/local'
+sudo make install VERBOSE=1 'PREFIX'='/usr/local'
+sudo ldconfig
+
+### Check out no1msd/mstch, workdir build ###
+
+mkdir -p '/usr/local/src' && cd '/usr/local/src'
+if [[ ! -d '/usr/local/src'/'mstch' ]]; then 
+	git clone https://github.com/'no1msd/mstch'
+fi
+mkdir -p '/usr/local/src'/'mstch'/'build' && cd '/usr/local/src'/'mstch'/'build'
+git checkout $(git describe --abbrev=0 --tags)
+
+### Build and install no1msd/mstch ###
+
+CXXFLAGS="$CXXFLAGS -fPIC" CFLAGS="$CFLAGS -fPIC" cmake -D'BUILD_SHARED_LIBS'='ON' '..'
+make -j '4' VERBOSE=1 
+sudo make install VERBOSE=1 
+sudo ldconfig
+
+### Check out facebook/fbthrift, workdir thrift ###
+
+mkdir -p '/usr/local/src' && cd '/usr/local/src'
+if [[ ! -d '/usr/local/src'/'fbthrift' ]]; then 
+	git clone https://github.com/'facebook/fbthrift'
+fi
+mkdir -p '/usr/local/src'/'fbthrift'/'thrift' && cd '/usr/local/src'/'fbthrift'/'thrift'
+git checkout '2e3a85eb29e0cc3bad910093656bc2196f9e96ae'
+
+### Build and install fbthrift/thrift ###
+
+CXXFLAGS="$CXXFLAGS -fPIC" CFLAGS="$CFLAGS -fPIC" cmake -D'BUILD_SHARED_LIBS'='ON' '..'
+make -j '4' VERBOSE=1 
+sudo make install VERBOSE=1 
+sudo ldconfig
+
+### Install thrift python modules ###
+
+mkdir -p '/usr/local/src'/'fbthrift/thrift/lib/py' && cd '/usr/local/src'/'fbthrift/thrift/lib/py'
+sudo python setup.py install
+
+### Check out hyperic/sigar, workdir . ###
+
+mkdir -p '/usr/local/src' && cd '/usr/local/src'
+if [[ ! -d '/usr/local/src'/'sigar' ]]; then 
+	git clone https://github.com/'hyperic/sigar'
+fi
+mkdir -p '/usr/local/src'/'sigar'/'.' && cd '/usr/local/src'/'sigar'/'.'
+
+### Build and install sigar ###
+
+./autogen.sh
+LDFLAGS="$LDFLAGS" CFLAGS="$CFLAGS" CPPFLAGS="$CPPFLAGS" ./configure 'CFLAGS'='-fgnu89-inline'
+make -j '4' VERBOSE=1 
+sudo make install VERBOSE=1 
+sudo ldconfig
+
+### Check out zeromq/libzmq, workdir . ###
+
+mkdir -p '/usr/local/src' && cd '/usr/local/src'
+if [[ ! -d '/usr/local/src'/'libzmq' ]]; then 
+	git clone https://github.com/'zeromq/libzmq'
+fi
+mkdir -p '/usr/local/src'/'libzmq'/'.' && cd '/usr/local/src'/'libzmq'/'.'
+git checkout 'v4.2.5'
+
+### Build and install zeromq/libzmq ###
+
+./autogen.sh
+LDFLAGS="$LDFLAGS" CFLAGS="$CFLAGS" CPPFLAGS="$CPPFLAGS" ./configure 
+make -j '4' VERBOSE=1 
+sudo make install VERBOSE=1 
+sudo ldconfig
+
+### Check out facebook/fbzmq, workdir fbzmq/build ###
+
+mkdir -p '/usr/local/src' && cd '/usr/local/src'
+if [[ ! -d '/usr/local/src'/'fbzmq' ]]; then 
+	git clone https://github.com/'facebook/fbzmq'
+fi
+mkdir -p '/usr/local/src'/'fbzmq'/'fbzmq/build' && cd '/usr/local/src'/'fbzmq'/'fbzmq/build'
+git checkout '8fba3b727c8194031351cefee71bd36ba3486645'
+
+### Build and install fbzmq/fbzmq/build ###
+
+CXXFLAGS="$CXXFLAGS -fPIC" CFLAGS="$CFLAGS -fPIC" cmake -D'BUILD_SHARED_LIBS'='ON' '..'
+PYTHONPATH="$PYTHONPATH:"'/usr/local'/lib/python2.7/site-packages make -j '4'
+sudo make install
+sudo ldconfig
+
+### Install fbzmq python modules ###
+
+mkdir -p '/usr/local/src'/'fbzmq/fbzmq/py' && cd '/usr/local/src'/'fbzmq/fbzmq/py'
+sudo python setup.py install
+
+### Check out google/re2, workdir build ###
+
+mkdir -p '/usr/local/src' && cd '/usr/local/src'
+if [[ ! -d '/usr/local/src'/'re2' ]]; then 
+	git clone https://github.com/'google/re2'
+fi
+mkdir -p '/usr/local/src'/'re2'/'build' && cd '/usr/local/src'/'re2'/'build'
+
+### Build and install google/re2 ###
+
+CXXFLAGS="$CXXFLAGS -fPIC" CFLAGS="$CFLAGS -fPIC" cmake -D'BUILD_SHARED_LIBS'='ON' '..'
+make -j '4' VERBOSE=1 
+sudo make install VERBOSE=1 
+sudo ldconfig
+
+### Check out thom311/libnl, workdir . ###
+
+mkdir -p '/usr/local/src' && cd '/usr/local/src'
+if [[ ! -d '/usr/local/src'/'libnl' ]]; then 
+	git clone https://github.com/'thom311/libnl'
+fi
+mkdir -p '/usr/local/src'/'libnl'/'.' && cd '/usr/local/src'/'libnl'/'.'
+git checkout 'libnl3_2_25'
+
+### Build and install thom311/libnl ###
+
+curl -O https://raw.githubusercontent.com/facebook/openr/master/build/fix-route-obj-attr-list.patch
+git apply 'fix-route-obj-attr-list.patch'
+./autogen.sh
+LDFLAGS="$LDFLAGS" CFLAGS="$CFLAGS" CPPFLAGS="$CPPFLAGS" ./configure 
+make -j '4' VERBOSE=1 
+sudo make install VERBOSE=1 
+sudo ldconfig
+
+### Check out facebook/openr, workdir build ###
+
+mkdir -p '/usr/local/src' && cd '/usr/local/src'
+if [[ ! -d '/usr/local/src'/'openr' ]]; then 
+	git clone https://github.com/'facebook/openr'
+fi
+mkdir -p '/usr/local/src'/'openr'/'build' && cd '/usr/local/src'/'openr'/'build'
+
+### Build and install openr/build ###
+
+CXXFLAGS="$CXXFLAGS -fPIC" CFLAGS="$CFLAGS -fPIC" cmake -D'BUILD_SHARED_LIBS'='ON' -D'ADD_ROOT_TESTS'='OFF' '..'
+PYTHONPATH="$PYTHONPATH:"'/usr/local'/lib/python2.7/site-packages make -j '4'
+sudo make install
+sudo ldconfig
+
+### Install OpenR python modules ###
+
+mkdir -p '/usr/local/src'/'openr/openr/py' && cd '/usr/local/src'/'openr/openr/py'
+sudo pip install cffi future pathlib 'networkx==2.2'
+sudo python setup.py build
+sudo python setup.py install
+
+### Run openr tests ###
+
+mkdir -p '/usr/local/src'/'openr/build' && cd '/usr/local/src'/'openr/build'
+CTEST_OUTPUT_ON_FAILURE=TRUE make test
+

--- a/ipmininet/install/build_openr-rc-20190419-11514.sh
+++ b/ipmininet/install/build_openr-rc-20190419-11514.sh
@@ -8,19 +8,9 @@ apt-get install -yq gcc-'5' g++-'5'
 update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-'5' 40 --slave /usr/bin/g++ g++ /usr/bin/g++-'5'
 update-alternatives --config gcc
 
-PY_MAJOR=${PY_MAJOR:-2}
-
-if [ "$PY_MAJOR" -ne 2 ] && [ "$PY_MAJOR" -ne 3 ]; then
-    >&2 echo "PY_MAJOR must be set to either 2 or 3."
-    exit 1
-fi
-
-PY_BIN="python$PY_MAJOR"
-PIP_BIN="pip$PY_MAJOR"
-
-PY_VERSION="$($PY_BIN --version 2>&1)"
+PY_VERSION="$(python3 --version 2>&1)"
 PY_MINOR=$(sed -e 's/\(Python \)\([[:digit:]]\)\.\([[:digit:]]\)\(.*\)/\3/g' <<< "$PY_VERSION")
-PY_LIB_PATH="/usr/local/lib/python$PY_MAJOR.$PY_MINOR/site-packages"
+PY_LIB_PATH="/usr/local/lib/python3.$PY_MINOR/site-packages"
 echo "PY_LIB_PATH: $PY_LIB_PATH"
 
 export CCACHE_DIR='/ccache' CC="ccache ${CC:-gcc}" CXX="ccache ${CXX:-g++}"
@@ -179,7 +169,7 @@ sudo ldconfig
 ### Install thrift python modules ###
 
 mkdir -p '/usr/local/src'/'fbthrift/thrift/lib/py' && cd '/usr/local/src'/'fbthrift/thrift/lib/py'
-PYTHONPATH="$PYTHONPATH:$PY_LIB_PATH" sudo $PY_BIN setup.py install
+PYTHONPATH="$PYTHONPATH:$PY_LIB_PATH" sudo python3 setup.py install
 
 ### Check out hyperic/sigar, workdir . ###
 
@@ -234,7 +224,7 @@ sudo ldconfig
 ### Install fbzmq python modules ###
 
 mkdir -p '/usr/local/src'/'fbzmq/fbzmq/py' && cd '/usr/local/src'/'fbzmq/fbzmq/py'
-PYTHONPATH="$PYTHONPATH:$PY_LIB_PATH" sudo $PY_BIN setup.py install
+PYTHONPATH="$PYTHONPATH:$PY_LIB_PATH" sudo python3 setup.py install
 
 ### Check out google/re2, workdir build ###
 
@@ -290,9 +280,9 @@ sudo ldconfig
 ### Install OpenR python modules ###
 
 mkdir -p '/usr/local/src'/'openr/openr/py' && cd '/usr/local/src'/'openr/openr/py'
-PYTHONPATH="$PYTHONPATH:$PY_LIB_PATH" sudo $PIP_BIN install cffi future pathlib 'networkx==2.2'
-PYTHONPATH="$PYTHONPATH:$PY_LIB_PATH" sudo $PY_BIN setup.py build
-PYTHONPATH="$PYTHONPATH:$PY_LIB_PATH" sudo $PY_BIN setup.py install
+PYTHONPATH="$PYTHONPATH:$PY_LIB_PATH" sudo pip3 install cffi future pathlib 'networkx==2.2'
+PYTHONPATH="$PYTHONPATH:$PY_LIB_PATH" sudo python3 setup.py build
+PYTHONPATH="$PYTHONPATH:$PY_LIB_PATH" sudo python3 setup.py install
 
 ### Run openr tests ###
 

--- a/ipmininet/install/build_openr-rc-20190419-11514.sh
+++ b/ipmininet/install/build_openr-rc-20190419-11514.sh
@@ -10,21 +10,17 @@ update-alternatives --config gcc
 
 PY_MAJOR=${PY_MAJOR:-2}
 
-if [ "$PY_MAJOR" -eq 2 ]; then
-    PY_BIN=python2
-    PIP_BIN=pip2
-elif [ "$PY_MAJOR" -eq 3 ]; then
-    PY_BIN=python3
-    PIP_BIN=pip3
-else
-    >&2 echo "PYTHON_VERSION must be set to either 2 or 3."
+if [ "$PY_MAJOR" -ne 2 ] && [ "$PY_MAJOR" -ne 3 ]; then
+    >&2 echo "PY_MAJOR must be set to either 2 or 3."
     exit 1
 fi
 
+PY_BIN="python$PY_MAJOR"
+PIP_BIN="pip$PY_MAJOR"
+
 PY_VERSION="$($PY_BIN --version 2>&1)"
-PY_MA=$(sed -e 's/\(Python \)\([[:digit:]]\)\.\([[:digit:]]\)\(.*\)/\2/g' <<< "$PY_VERSION")
-PY_MI=$(sed -e 's/\(Python \)\([[:digit:]]\)\.\([[:digit:]]\)\(.*\)/\3/g' <<< "$PY_VERSION")
-PY_LIB_PATH="/usr/local/lib/python$PY_MA.$PY_MI/site-packages"
+PY_MINOR=$(sed -e 's/\(Python \)\([[:digit:]]\)\.\([[:digit:]]\)\(.*\)/\3/g' <<< "$PY_VERSION")
+PY_LIB_PATH="/usr/local/lib/python$PY_MAJOR.$PY_MINOR/site-packages"
 echo "PY_LIB_PATH: $PY_LIB_PATH"
 
 export CCACHE_DIR='/ccache' CC="ccache ${CC:-gcc}" CXX="ccache ${CXX:-g++}"

--- a/ipmininet/install/build_openr-rc-20190419-11514.sh
+++ b/ipmininet/install/build_openr-rc-20190419-11514.sh
@@ -8,6 +8,22 @@ apt-get install -yq gcc-'5' g++-'5'
 update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-'5' 40 --slave /usr/bin/g++ g++ /usr/bin/g++-'5'
 update-alternatives --config gcc
 
+FOLLY_REV="3ceffd7d145be3c85a2aae39f99eb86ea730bdcc"
+SODIUM_REV="6bece9c8c45259998f83ce243b1933e76c03f545"
+FIZZ_REV="53e9df90e7876ba207deacbf60703bfbee31c442"
+GTEST_REV="release-1.8.1"
+RSOCKET_REV="8584e390e26c1eccae8da4283b42e93f7d4926f0"
+WANGLE_REV="f2f8e1996739df1fc8ab1e003a1bc6472bd5b9bd"
+ZSTD_REV="83b51e9f886be7c2a4d477b6e7bc6db831791d8d"
+MSTCH_REV="ff459067bd02e80dc399006bb610238223d41c50"
+FBTHRIFT_REV="2e3a85eb29e0cc3bad910093656bc2196f9e96ae"
+SIGAR_REV="ad47dc3b494e9293d1f087aebb099bdba832de5e"
+ZMQ_REV="v4.2.5"
+FBZMQ_REV="8fba3b727c8194031351cefee71bd36ba3486645"
+RE2_REV="653f9e2a6a17bcdf8dba2b3f8671aa8880efca29"
+LIBNL_REV="libnl3_2_25"
+OPENR_REV="rc-20190419-11514"
+
 PY_VERSION="$(python3 --version 2>&1)"
 PY_MINOR=$(sed -e 's/\(Python \)\([[:digit:]]\)\.\([[:digit:]]\)\(.*\)/\3/g' <<< "$PY_VERSION")
 PY_LIB_PATH="/usr/local/lib/python3.$PY_MINOR/site-packages"
@@ -29,7 +45,7 @@ if [[ ! -d '/usr/local/src'/'folly' ]]; then
 	git clone https://github.com/'facebook/folly'
 fi
 mkdir -p '/usr/local/src'/'folly'/'_build' && cd '/usr/local/src'/'folly'/'_build'
-git checkout '3ceffd7d145be3c85a2aae39f99eb86ea730bdcc'
+git checkout $FOLLY_REV
 
 ### Build and install facebook/folly ###
 
@@ -45,7 +61,7 @@ if [[ ! -d '/usr/local/src'/'libsodium' ]]; then
 	git clone https://github.com/'jedisct1/libsodium'
 fi
 mkdir -p '/usr/local/src'/'libsodium'/'.' && cd '/usr/local/src'/'libsodium'/'.'
-git checkout '6bece9c8c45259998f83ce243b1933e76c03f545'
+git checkout $SODIUM_REV
 
 ### Build and install jedisct1/libsodium ###
 
@@ -62,7 +78,7 @@ if [[ ! -d '/usr/local/src'/'fizz' ]]; then
 	git clone https://github.com/'facebookincubator/fizz'
 fi
 mkdir -p '/usr/local/src'/'fizz'/'fizz/build' && cd '/usr/local/src'/'fizz'/'fizz/build'
-git checkout '53e9df90e7876ba207deacbf60703bfbee31c442'
+git checkout $FIZZ_REV
 
 ### Build and install fizz/fizz/build ###
 
@@ -78,7 +94,7 @@ if [[ ! -d '/usr/local/src'/'googletest' ]]; then
 	git clone https://github.com/'google/googletest'
 fi
 mkdir -p '/usr/local/src'/'googletest'/'build' && cd '/usr/local/src'/'googletest'/'build'
-git checkout 'release-1.8.1'
+git checkout $GTEST_REV
 
 ### Build and install google/googletest ###
 
@@ -94,7 +110,7 @@ if [[ ! -d '/usr/local/src'/'rsocket-cpp' ]]; then
 	git clone https://github.com/'rsocket/rsocket-cpp'
 fi
 mkdir -p '/usr/local/src'/'rsocket-cpp'/'rsocket' && cd '/usr/local/src'/'rsocket-cpp'/'rsocket'
-git checkout '8584e390e26c1eccae8da4283b42e93f7d4926f0'
+git checkout $RSOCKET_REV
 
 ### Build and install rsocket-cpp/rsocket ###
 
@@ -110,7 +126,7 @@ if [[ ! -d '/usr/local/src'/'wangle' ]]; then
 	git clone https://github.com/'facebook/wangle'
 fi
 mkdir -p '/usr/local/src'/'wangle'/'wangle/build' && cd '/usr/local/src'/'wangle'/'wangle/build'
-git checkout 'f2f8e1996739df1fc8ab1e003a1bc6472bd5b9bd'
+git checkout $WANGLE_REV
 
 ### Build and install wangle/wangle/build ###
 
@@ -126,7 +142,7 @@ if [[ ! -d '/usr/local/src'/'zstd' ]]; then
 	git clone https://github.com/'facebook/zstd'
 fi
 mkdir -p '/usr/local/src'/'zstd'/'.' && cd '/usr/local/src'/'zstd'/'.'
-git checkout '83b51e9f886be7c2a4d477b6e7bc6db831791d8d'
+git checkout $ZSTD_REV
 
 ### Build and install zstd ###
 
@@ -141,7 +157,7 @@ if [[ ! -d '/usr/local/src'/'mstch' ]]; then
 	git clone https://github.com/'no1msd/mstch'
 fi
 mkdir -p '/usr/local/src'/'mstch'/'build' && cd '/usr/local/src'/'mstch'/'build'
-git checkout 'ff459067bd02e80dc399006bb610238223d41c50'
+git checkout $MSTCH_REV
 
 ### Build and install no1msd/mstch ###
 
@@ -157,7 +173,7 @@ if [[ ! -d '/usr/local/src'/'fbthrift' ]]; then
 	git clone https://github.com/'facebook/fbthrift'
 fi
 mkdir -p '/usr/local/src'/'fbthrift'/'thrift' && cd '/usr/local/src'/'fbthrift'/'thrift'
-git checkout '2e3a85eb29e0cc3bad910093656bc2196f9e96ae'
+git checkout $FBTHRIFT_REV
 
 ### Build and install fbthrift/thrift ###
 
@@ -178,7 +194,7 @@ if [[ ! -d '/usr/local/src'/'sigar' ]]; then
 	git clone https://github.com/'hyperic/sigar'
 fi
 mkdir -p '/usr/local/src'/'sigar'/'.' && cd '/usr/local/src'/'sigar'/'.'
-git checkout 'ad47dc3b494e9293d1f087aebb099bdba832de5e'
+git checkout $SIGAR_REV
 
 ### Build and install sigar ###
 
@@ -195,7 +211,7 @@ if [[ ! -d '/usr/local/src'/'libzmq' ]]; then
 	git clone https://github.com/'zeromq/libzmq'
 fi
 mkdir -p '/usr/local/src'/'libzmq'/'.' && cd '/usr/local/src'/'libzmq'/'.'
-git checkout 'v4.2.5'
+git checkout $ZMQ_REV
 
 ### Build and install zeromq/libzmq ###
 
@@ -212,7 +228,7 @@ if [[ ! -d '/usr/local/src'/'fbzmq' ]]; then
 	git clone https://github.com/'facebook/fbzmq'
 fi
 mkdir -p '/usr/local/src'/'fbzmq'/'fbzmq/build' && cd '/usr/local/src'/'fbzmq'/'fbzmq/build'
-git checkout '8fba3b727c8194031351cefee71bd36ba3486645'
+git checkout $FBZMQ_REV
 
 ### Build and install fbzmq/fbzmq/build ###
 
@@ -233,7 +249,7 @@ if [[ ! -d '/usr/local/src'/'re2' ]]; then
 	git clone https://github.com/'google/re2'
 fi
 mkdir -p '/usr/local/src'/'re2'/'build' && cd '/usr/local/src'/'re2'/'build'
-git checkout '653f9e2a6a17bcdf8dba2b3f8671aa8880efca29'
+git checkout $RE2_REV
 
 ### Build and install google/re2 ###
 
@@ -249,11 +265,11 @@ if [[ ! -d '/usr/local/src'/'libnl' ]]; then
 	git clone https://github.com/'thom311/libnl'
 fi
 mkdir -p '/usr/local/src'/'libnl'/'.' && cd '/usr/local/src'/'libnl'/'.'
-git checkout 'libnl3_2_25'
+git checkout $LIBNL_REV
 
 ### Build and install thom311/libnl ###
 
-curl -O https://raw.githubusercontent.com/facebook/openr/rc-20190419-11514/build/fix-route-obj-attr-list.patch
+curl -O https://raw.githubusercontent.com/facebook/openr/$OPENR_REV/build/fix-route-obj-attr-list.patch
 git apply 'fix-route-obj-attr-list.patch'
 ./autogen.sh
 LDFLAGS="$LDFLAGS" CFLAGS="$CFLAGS" CPPFLAGS="$CPPFLAGS" ./configure 
@@ -268,7 +284,7 @@ if [[ ! -d '/usr/local/src'/'openr' ]]; then
 	git clone https://github.com/'facebook/openr'
 fi
 mkdir -p '/usr/local/src'/'openr'/'build' && cd '/usr/local/src'/'openr'/'build'
-git checkout 'rc-20190419-11514'
+git checkout $OPENR_REV
 
 ### Build and install openr/build ###
 

--- a/ipmininet/install/build_openr-rc-20190419-11514.sh
+++ b/ipmininet/install/build_openr-rc-20190419-11514.sh
@@ -40,7 +40,7 @@ if [[ ! -d '/usr/local/src'/'libsodium' ]]; then
 	git clone https://github.com/'jedisct1/libsodium'
 fi
 mkdir -p '/usr/local/src'/'libsodium'/'.' && cd '/usr/local/src'/'libsodium'/'.'
-git checkout 'stable'
+git checkout '6bece9c8c45259998f83ce243b1933e76c03f545'
 
 ### Build and install jedisct1/libsodium ###
 
@@ -57,6 +57,7 @@ if [[ ! -d '/usr/local/src'/'fizz' ]]; then
 	git clone https://github.com/'facebookincubator/fizz'
 fi
 mkdir -p '/usr/local/src'/'fizz'/'fizz/build' && cd '/usr/local/src'/'fizz'/'fizz/build'
+git checkout '53e9df90e7876ba207deacbf60703bfbee31c442'
 
 ### Build and install fizz/fizz/build ###
 
@@ -88,6 +89,7 @@ if [[ ! -d '/usr/local/src'/'rsocket-cpp' ]]; then
 	git clone https://github.com/'rsocket/rsocket-cpp'
 fi
 mkdir -p '/usr/local/src'/'rsocket-cpp'/'rsocket' && cd '/usr/local/src'/'rsocket-cpp'/'rsocket'
+git checkout '8584e390e26c1eccae8da4283b42e93f7d4926f0'
 
 ### Build and install rsocket-cpp/rsocket ###
 
@@ -119,7 +121,7 @@ if [[ ! -d '/usr/local/src'/'zstd' ]]; then
 	git clone https://github.com/'facebook/zstd'
 fi
 mkdir -p '/usr/local/src'/'zstd'/'.' && cd '/usr/local/src'/'zstd'/'.'
-git checkout $(git describe --abbrev=0 --tags origin/master)
+git checkout '83b51e9f886be7c2a4d477b6e7bc6db831791d8d'
 
 ### Build and install zstd ###
 
@@ -134,7 +136,7 @@ if [[ ! -d '/usr/local/src'/'mstch' ]]; then
 	git clone https://github.com/'no1msd/mstch'
 fi
 mkdir -p '/usr/local/src'/'mstch'/'build' && cd '/usr/local/src'/'mstch'/'build'
-git checkout $(git describe --abbrev=0 --tags)
+git checkout 'ff459067bd02e80dc399006bb610238223d41c50'
 
 ### Build and install no1msd/mstch ###
 
@@ -171,6 +173,7 @@ if [[ ! -d '/usr/local/src'/'sigar' ]]; then
 	git clone https://github.com/'hyperic/sigar'
 fi
 mkdir -p '/usr/local/src'/'sigar'/'.' && cd '/usr/local/src'/'sigar'/'.'
+git checkout 'ad47dc3b494e9293d1f087aebb099bdba832de5e'
 
 ### Build and install sigar ###
 
@@ -225,6 +228,7 @@ if [[ ! -d '/usr/local/src'/'re2' ]]; then
 	git clone https://github.com/'google/re2'
 fi
 mkdir -p '/usr/local/src'/'re2'/'build' && cd '/usr/local/src'/'re2'/'build'
+git checkout '653f9e2a6a17bcdf8dba2b3f8671aa8880efca29'
 
 ### Build and install google/re2 ###
 
@@ -259,6 +263,7 @@ if [[ ! -d '/usr/local/src'/'openr' ]]; then
 	git clone https://github.com/'facebook/openr'
 fi
 mkdir -p '/usr/local/src'/'openr'/'build' && cd '/usr/local/src'/'openr'/'build'
+git checkout 'rc-20190419-11514'
 
 ### Build and install openr/build ###
 

--- a/ipmininet/install/build_openr-rc-20190419-11514.sh
+++ b/ipmininet/install/build_openr-rc-20190419-11514.sh
@@ -248,7 +248,7 @@ git checkout 'libnl3_2_25'
 
 ### Build and install thom311/libnl ###
 
-curl -O https://raw.githubusercontent.com/facebook/openr/master/build/fix-route-obj-attr-list.patch
+curl -O https://raw.githubusercontent.com/facebook/openr/rc-20190419-11514/build/fix-route-obj-attr-list.patch
 git apply 'fix-route-obj-attr-list.patch'
 ./autogen.sh
 LDFLAGS="$LDFLAGS" CFLAGS="$CFLAGS" CPPFLAGS="$CPPFLAGS" ./configure 

--- a/ipmininet/install/build_openr-rc-20190419-11514.sh
+++ b/ipmininet/install/build_openr-rc-20190419-11514.sh
@@ -29,7 +29,8 @@ PY_MINOR=$(sed -e 's/\(Python \)\([[:digit:]]\)\.\([[:digit:]]\)\(.*\)/\3/g' <<<
 PY_LIB_PATH="/usr/local/lib/python3.$PY_MINOR/site-packages"
 echo "PY_LIB_PATH: $PY_LIB_PATH"
 
-export MAKEFLAGS="$MAKEFLAGS -j $(nproc)"
+NPROC=$(nproc 2> /dev/null || echo 1)
+export MAKEFLAGS="$MAKEFLAGS -j $NPROC"
 
 export CCACHE_DIR='/ccache' CC="ccache ${CC:-gcc}" CXX="ccache ${CXX:-g++}"
 ### Diagnostics ###
@@ -117,6 +118,7 @@ git checkout $RSOCKET_REV
 ### Build and install rsocket-cpp/rsocket ###
 
 CXXFLAGS="$CXXFLAGS -fPIC" CFLAGS="$CFLAGS -fPIC" cmake -D'BUILD_SHARED_LIBS'='ON' '..'
+make gmock
 make VERBOSE=1
 sudo make install VERBOSE=1 
 sudo ldconfig
@@ -291,6 +293,7 @@ git checkout $OPENR_REV
 ### Build and install openr/build ###
 
 CXXFLAGS="$CXXFLAGS -fPIC" CFLAGS="$CFLAGS -fPIC" cmake -D'BUILD_SHARED_LIBS'='ON' -D'ADD_ROOT_TESTS'='OFF' '..'
+make Decision-cpp2-obj Dual-cpp2-obj HealthChecker-cpp2-obj KvStore-cpp2-obj LinkMonitor-cpp2-obj
 PYTHONPATH="$PYTHONPATH:$PY_LIB_PATH" make
 sudo make install
 sudo ldconfig

--- a/ipmininet/install/build_openr-rc-20190419-11514.sh
+++ b/ipmininet/install/build_openr-rc-20190419-11514.sh
@@ -29,6 +29,8 @@ PY_MINOR=$(sed -e 's/\(Python \)\([[:digit:]]\)\.\([[:digit:]]\)\(.*\)/\3/g' <<<
 PY_LIB_PATH="/usr/local/lib/python3.$PY_MINOR/site-packages"
 echo "PY_LIB_PATH: $PY_LIB_PATH"
 
+export MAKEFLAGS="$MAKEFLAGS -j $(nproc)"
+
 export CCACHE_DIR='/ccache' CC="ccache ${CC:-gcc}" CXX="ccache ${CXX:-g++}"
 ### Diagnostics ###
 
@@ -50,7 +52,7 @@ git checkout $FOLLY_REV
 ### Build and install facebook/folly ###
 
 CXXFLAGS="$CXXFLAGS -fPIC" CFLAGS="$CFLAGS -fPIC" cmake -D'BUILD_SHARED_LIBS'='ON' '..'
-make -j '4' VERBOSE=1 
+make VERBOSE=1
 sudo make install VERBOSE=1 
 sudo ldconfig
 
@@ -67,7 +69,7 @@ git checkout $SODIUM_REV
 
 ./autogen.sh
 LDFLAGS="$LDFLAGS" CFLAGS="$CFLAGS" CPPFLAGS="$CPPFLAGS" ./configure 
-make -j '4' VERBOSE=1 
+make VERBOSE=1
 sudo make install VERBOSE=1 
 sudo ldconfig
 
@@ -83,7 +85,7 @@ git checkout $FIZZ_REV
 ### Build and install fizz/fizz/build ###
 
 CXXFLAGS="$CXXFLAGS -fPIC" CFLAGS="$CFLAGS -fPIC" cmake -D'BUILD_SHARED_LIBS'='ON' '..'
-make -j '4' VERBOSE=1 
+make VERBOSE=1
 sudo make install VERBOSE=1 
 sudo ldconfig
 
@@ -99,7 +101,7 @@ git checkout $GTEST_REV
 ### Build and install google/googletest ###
 
 CXXFLAGS="$CXXFLAGS -fPIC" CFLAGS="$CFLAGS -fPIC" cmake -D'BUILD_GTEST'='ON' -D'BUILD_SHARED_LIBS'='OFF' '..'
-make -j '4' VERBOSE=1 
+make VERBOSE=1
 sudo make install VERBOSE=1 
 sudo ldconfig
 
@@ -115,7 +117,7 @@ git checkout $RSOCKET_REV
 ### Build and install rsocket-cpp/rsocket ###
 
 CXXFLAGS="$CXXFLAGS -fPIC" CFLAGS="$CFLAGS -fPIC" cmake -D'BUILD_SHARED_LIBS'='ON' '..'
-make -j '4' VERBOSE=1 
+make VERBOSE=1
 sudo make install VERBOSE=1 
 sudo ldconfig
 
@@ -131,7 +133,7 @@ git checkout $WANGLE_REV
 ### Build and install wangle/wangle/build ###
 
 CXXFLAGS="$CXXFLAGS -fPIC" CFLAGS="$CFLAGS -fPIC" cmake -D'BUILD_SHARED_LIBS'='ON' -D'BUILD_TESTS'='OFF' '..'
-make -j '4' VERBOSE=1 
+make VERBOSE=1
 sudo make install VERBOSE=1 
 sudo ldconfig
 
@@ -146,7 +148,7 @@ git checkout $ZSTD_REV
 
 ### Build and install zstd ###
 
-make -j '4' VERBOSE=1 'PREFIX'='/usr/local'
+make VERBOSE=1 'PREFIX'='/usr/local'
 sudo make install VERBOSE=1 'PREFIX'='/usr/local'
 sudo ldconfig
 
@@ -162,7 +164,7 @@ git checkout $MSTCH_REV
 ### Build and install no1msd/mstch ###
 
 CXXFLAGS="$CXXFLAGS -fPIC" CFLAGS="$CFLAGS -fPIC" cmake -D'BUILD_SHARED_LIBS'='ON' '..'
-make -j '4' VERBOSE=1 
+make VERBOSE=1
 sudo make install VERBOSE=1 
 sudo ldconfig
 
@@ -178,7 +180,7 @@ git checkout $FBTHRIFT_REV
 ### Build and install fbthrift/thrift ###
 
 CXXFLAGS="$CXXFLAGS -fPIC" CFLAGS="$CFLAGS -fPIC" cmake -D'BUILD_SHARED_LIBS'='ON' '..'
-make -j '4' VERBOSE=1 
+make VERBOSE=1
 sudo make install VERBOSE=1 
 sudo ldconfig
 
@@ -200,7 +202,7 @@ git checkout $SIGAR_REV
 
 ./autogen.sh
 LDFLAGS="$LDFLAGS" CFLAGS="$CFLAGS" CPPFLAGS="$CPPFLAGS" ./configure 'CFLAGS'='-fgnu89-inline'
-make -j '4' VERBOSE=1 
+make VERBOSE=1
 sudo make install VERBOSE=1 
 sudo ldconfig
 
@@ -217,7 +219,7 @@ git checkout $ZMQ_REV
 
 ./autogen.sh
 LDFLAGS="$LDFLAGS" CFLAGS="$CFLAGS" CPPFLAGS="$CPPFLAGS" ./configure 
-make -j '4' VERBOSE=1 
+make VERBOSE=1
 sudo make install VERBOSE=1 
 sudo ldconfig
 
@@ -233,7 +235,7 @@ git checkout $FBZMQ_REV
 ### Build and install fbzmq/fbzmq/build ###
 
 CXXFLAGS="$CXXFLAGS -fPIC" CFLAGS="$CFLAGS -fPIC" cmake -D'BUILD_SHARED_LIBS'='ON' '..'
-PYTHONPATH="$PYTHONPATH:$PY_LIB_PATH" make -j '4'
+PYTHONPATH="$PYTHONPATH:$PY_LIB_PATH" make
 sudo make install
 sudo ldconfig
 
@@ -254,7 +256,7 @@ git checkout $RE2_REV
 ### Build and install google/re2 ###
 
 CXXFLAGS="$CXXFLAGS -fPIC" CFLAGS="$CFLAGS -fPIC" cmake -D'BUILD_SHARED_LIBS'='ON' '..'
-make -j '4' VERBOSE=1 
+make VERBOSE=1
 sudo make install VERBOSE=1 
 sudo ldconfig
 
@@ -273,7 +275,7 @@ curl -O https://raw.githubusercontent.com/facebook/openr/$OPENR_REV/build/fix-ro
 git apply 'fix-route-obj-attr-list.patch'
 ./autogen.sh
 LDFLAGS="$LDFLAGS" CFLAGS="$CFLAGS" CPPFLAGS="$CPPFLAGS" ./configure 
-make -j '4' VERBOSE=1 
+make VERBOSE=1
 sudo make install VERBOSE=1 
 sudo ldconfig
 
@@ -289,7 +291,7 @@ git checkout $OPENR_REV
 ### Build and install openr/build ###
 
 CXXFLAGS="$CXXFLAGS -fPIC" CFLAGS="$CFLAGS -fPIC" cmake -D'BUILD_SHARED_LIBS'='ON' -D'ADD_ROOT_TESTS'='OFF' '..'
-PYTHONPATH="$PYTHONPATH:$PY_LIB_PATH" make -j '4'
+PYTHONPATH="$PYTHONPATH:$PY_LIB_PATH" make
 sudo make install
 sudo ldconfig
 

--- a/ipmininet/install/build_openr-rc-20190419-11514.sh
+++ b/ipmininet/install/build_openr-rc-20190419-11514.sh
@@ -21,8 +21,10 @@ else
     exit 1
 fi
 
-PY_VERSION=$($PY_BIN --version | sed -e 's/\(Python \)\([[:digit:]]\.[[:digit:]]\)\(.*\)/\2/g')
-PY_LIB_PATH="/usr/local/lib/python${PY_VERSION}/site-packages"
+PY_VERSION="$($PY_BIN --version 2>&1)"
+PY_MA=$(sed -e 's/\(Python \)\([[:digit:]]\)\.\([[:digit:]]\)\(.*\)/\2/g' <<< "$PY_VERSION")
+PY_MI=$(sed -e 's/\(Python \)\([[:digit:]]\)\.\([[:digit:]]\)\(.*\)/\3/g' <<< "$PY_VERSION")
+PY_LIB_PATH="/usr/local/lib/python$PY_MA.$PY_MI/site-packages"
 echo "PY_LIB_PATH: $PY_LIB_PATH"
 
 export CCACHE_DIR='/ccache' CC="ccache ${CC:-gcc}" CXX="ccache ${CXX:-g++}"

--- a/ipmininet/install/build_vm.sh
+++ b/ipmininet/install/build_vm.sh
@@ -14,6 +14,9 @@ DEPS="python3 \
       python3-pip \
       git"
 
+IPMN_REPO="${IPMN_REPO:-https://github.com/cnp3/ipmininet.git}"
+IPMN_BRANCH="${IPMN_BRANCH:-master}"
+
 # Upgrade system and install dependencies
 sudo apt update -yq && sudo apt upgrade -yq
 sudo apt install -yq ${DEPS}
@@ -30,8 +33,9 @@ sudo pip3 install --upgrade pip
 sudo apt remove -yq python3-pip
 
 # Install ipmininet
-git clone https://github.com/cnp3/ipmininet.git
+[ ! -d "ipmininet" ] && git clone ${IPMN_REPO}
 pushd ipmininet
+git checkout -t origin/${IPMN_BRANCH}
 sudo pip3 install .
 sudo python3 -m ipmininet.install -af6
 popd

--- a/ipmininet/install/build_vm.sh
+++ b/ipmininet/install/build_vm.sh
@@ -16,6 +16,7 @@ DEPS="python3 \
 
 IPMN_REPO="${IPMN_REPO:-https://github.com/cnp3/ipmininet.git}"
 IPMN_BRANCH="${IPMN_BRANCH:-master}"
+IPMN_DIR="${IPMN_DIR:-ipmininet}"
 
 # Upgrade system and install dependencies
 sudo apt update -yq && sudo apt upgrade -yq
@@ -33,8 +34,9 @@ sudo pip3 install --upgrade pip
 sudo apt remove -yq python3-pip
 
 # Install ipmininet
-[ ! -d "ipmininet" ] && git clone ${IPMN_REPO}
-pushd ipmininet
+
+[ ! -d "$IPMN_DIR" ] && git clone ${IPMN_REPO} ${IPMN_DIR}
+pushd ${IPMN_DIR}
 git checkout -t origin/${IPMN_BRANCH}
 sudo pip3 install .
 sudo python3 -m ipmininet.install -af6

--- a/ipmininet/install/install.py
+++ b/ipmininet/install/install.py
@@ -10,7 +10,6 @@ from utils import supported_distributions, identify_distribution, sh
 
 MininetVersion = "2.3.0d6"
 FRRoutingVersion = "7.1"
-OpenrRelease = "rc-20190419-11514"
 
 os.environ["PATH"] = "%s:/sbin:/usr/sbin/:/usr/local/sbin" % os.environ["PATH"]
 
@@ -152,27 +151,16 @@ def install_frrouting(output_dir: str):
         break
 
 
-def install_openr(output_dir: str, openr_release=OpenrRelease,
-                  openr_remote="https://github.com/facebook/openr.git"):
-    dist.install("git")
-    openr_install = os.path.join(output_dir, "openr")
-    openr_build = os.path.join(openr_install, "build")
-    openr_buildscript = os.path.join(openr_build, "build_openr_debian.sh")
-    debian_system_builder = "debian_system_builder/debian_system_builder.py"
-    sh("git clone %s" % openr_remote,
-       cwd=output_dir)
-    sh("git checkout %s" % openr_release,
-       cwd=openr_install)
-    # Generate build script
-    with open(openr_buildscript, "w+") as f:
-        sh("python %s" % debian_system_builder,
-           stdout=f,
-           cwd=openr_build).wait()
-    # Make build script executable
-    os.chmod(openr_buildscript, stat.S_IRWXU)
+def install_openr(output_dir: str):
+    # It's not possible to get a build script with pinned dependencies from the
+    # OpenR github repository. The checked-in build script has the dependencies
+    # pinned manually. Builds and installs OpenR release rc-20190419-11514.
+    # https://github.com/facebook/openr/releases/tag/rc-20190419-11514
+    script_name = "build_openr-rc-20190419-11514.sh"
+    openr_buildscript = os.path.join("ipmininet/ipmininet/install/", script_name)
     # Execute build script
     sh(openr_buildscript,
-       cwd=openr_build,
+       cwd=output_dir,
        shell=True,
        executable="/bin/bash")
 

--- a/ipmininet/install/install.py
+++ b/ipmininet/install/install.py
@@ -151,7 +151,7 @@ def install_frrouting(output_dir: str):
         break
 
 
-def install_openr(output_dir: str, py_major="3"):
+def install_openr(output_dir: str, may_fail=False):
     # It's not possible to get a build script with pinned dependencies from the
     # OpenR github repository. The checked-in build script has the dependencies
     # pinned manually. Builds and installs OpenR release rc-20190419-11514.
@@ -160,11 +160,14 @@ def install_openr(output_dir: str, py_major="3"):
     openr_buildscript = os.path.join("ipmininet/ipmininet/install/",
                                      script_name)
     # Execute build script
-    sh(openr_buildscript,
-       env=dict(os.environ, PY_MAJOR=str(py_major)),
-       cwd=output_dir,
-       shell=True,
-       executable="/bin/bash")
+    p = sh(openr_buildscript,
+           cwd=output_dir,
+           shell=True,
+           executable="/bin/bash",
+           may_fail=may_fail)
+    # We should end here only if may_fail is True
+    if p.returncode != 0:
+        print("WARNING: Ignoring failed OpenR installation.", file=sys.stderr)
 
 
 def update_grub():

--- a/ipmininet/install/install.py
+++ b/ipmininet/install/install.py
@@ -151,15 +151,17 @@ def install_frrouting(output_dir: str):
         break
 
 
-def install_openr(output_dir: str):
+def install_openr(output_dir: str, py_major="3"):
     # It's not possible to get a build script with pinned dependencies from the
     # OpenR github repository. The checked-in build script has the dependencies
     # pinned manually. Builds and installs OpenR release rc-20190419-11514.
     # https://github.com/facebook/openr/releases/tag/rc-20190419-11514
     script_name = "build_openr-rc-20190419-11514.sh"
-    openr_buildscript = os.path.join("ipmininet/ipmininet/install/", script_name)
+    openr_buildscript = os.path.join("ipmininet/ipmininet/install/",
+                                     script_name)
     # Execute build script
     sh(openr_buildscript,
+       env=dict(os.environ, PY_MAJOR=str(py_major)),
        cwd=output_dir,
        shell=True,
        executable="/bin/bash")

--- a/ipmininet/install/install.py
+++ b/ipmininet/install/install.py
@@ -157,7 +157,7 @@ def install_openr(output_dir: str, may_fail=False):
     # pinned manually. Builds and installs OpenR release rc-20190419-11514.
     # https://github.com/facebook/openr/releases/tag/rc-20190419-11514
     script_name = "build_openr-rc-20190419-11514.sh"
-    openr_buildscript = os.path.join("ipmininet/ipmininet/install/",
+    openr_buildscript = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                      script_name)
     # Execute build script
     p = sh(openr_buildscript,


### PR DESCRIPTION
The build script previously generated from the OpenR repository didn't fix all dependencies properly. Therefore the OpenR build in the install scripts was broken. This PR starts from a freshly generated build script and contains commits that pin dependencies manually. Additionally, the OpenR python dependencies can be installed with either python2 or python3.

The vm build script (with OpenR installation) has been tested under Ubuntu 18.04.