### PR TITLE
[mininet vm] Checkout mininet with release tag

### DIFF
--- a/ipmininet/install/build_vm.sh
+++ b/ipmininet/install/build_vm.sh
@@ -27,7 +27,7 @@ sudo sed -i -e 's/^\(127\.0\.1\.1\).*/\1\tmininet-vm/' /etc/hosts
 
 # Install mininet
 pushd $HOME
-source <(curl -sL ${MN_INSTALL_SCRIPT_REMOTE})
+source <(curl -sL ${MN_INSTALL_SCRIPT_REMOTE}) ${MN_VERSION}
 
 # Update pip install
 sudo pip3 install --upgrade pip


### PR DESCRIPTION
The mininet release of the vm build script is pinned to a certain tag.
At the moment, this tag is only used for the download of the
'install-mininet-vm.sh' script. To chekcout mininet with the same tag,
the option has to be passed to the script.
See:
https://github.com/mininet/mininet/blob/master/util/vm/install-mininet-vm.sh#L40

Pass the release tag to the mininet vm script.