### PR TITLE
Zone delegation and dns root server hints

### DIFF
--- a/docs/daemons.rst
+++ b/docs/daemons.rst
@@ -515,6 +515,16 @@ if they fit in its domain name. Otherwise, another zone will be created.
 
             super().build(*args, **kwargs)
 
+By default, subdomains authority is delegated to the direct child zone name
+servers by copying the NS records of the child zone to the parent zone. You can
+remove this behavior, by zone, by setting the parameter ``subdomain_delegation``
+to ``False``. You can also delegate more zones by using the ``delegated_zones``
+parameter.
+
+By default, all DNS servers that are not root DNS servers have hints to the
+root DNS servers (if the root zone is added to the topology). This behavior
+can be disabled by setting the parameter ``hint_root_zone`` of ``Named`` to
+``False``.
 
 RADVD
 -----

--- a/ipmininet/examples/README.md
+++ b/ipmininet/examples/README.md
@@ -37,6 +37,7 @@ The following sections will detail the topologies.
    - [SpanningTreeAdjust](#spanningtreeadjust)
    - [SpanningTreeCost](#spanningtreecost)
    - [DNSNetwork](#dnsnetwork)
+   - [DNSAdvancedNetwork](#dnsadvancednetwork)
    - [IPv6SegmentRouting](#ipv6segmentrouting)
    - [TCNetwork](#tcnetwork)
    - [TCAdvancedNetwork](#tcadvancednetwork)
@@ -429,6 +430,15 @@ master dig @locahost -t AAAA server.mydomain.org
 slave dig @locahost -t NS mydomain.org
 slave dig @locahost -t AAAA server.mydomain.org
 ```
+
+## DNSAdvancedNetwork
+
+_topo name_ : dns_advanced_network
+_args_ : n/a
+
+This network has a full DNS architecture with root servers and zone delegation.
+You can query the full tree with dig as on the
+[DNSNetwork](#dnsnetwork) topology.
 
 ## IPv6SegmentRouting
 

--- a/ipmininet/examples/__main__.py
+++ b/ipmininet/examples/__main__.py
@@ -41,6 +41,7 @@ from .bgp_policies_3 import BGPPoliciesTopo3
 from .bgp_policies_adjust import BGPPoliciesAdjustTopo
 from .bgp_policies_5 import BGPPoliciesTopo5
 from .dns_network import DNSNetwork
+from .dns_advanced_network import DNSAdvancedNetwork
 from .srv6 import SRv6Topo
 from .tc_network import TCNet
 from .tc_advanced_network import TCAdvancedNet
@@ -82,6 +83,7 @@ TOPOS = {'simple_ospf_network': SimpleOSPFNet,
          'bgp_policies_adjust': BGPPoliciesAdjustTopo,
          'bgp_policies_5': BGPPoliciesTopo5,
          'dns_network': DNSNetwork,
+         'dns_advanced_network': DNSAdvancedNetwork,
          'ipv6_segment_routing': SRv6Topo,
          'tc_network': TCNet,
          'tc_advanced_network': TCAdvancedNet}

--- a/ipmininet/examples/dns_advanced_network.py
+++ b/ipmininet/examples/dns_advanced_network.py
@@ -1,0 +1,64 @@
+"""This file contains topology with a full DNS hierarchy"""
+
+from ipmininet.host.config import Named
+from ipmininet.iptopo import IPTopo
+
+
+class DNSAdvancedNetwork(IPTopo):
+    """This network runs a named daemon on both master and slave hosts.
+       The zone 'mydomain.org' is configured on both named daemons.
+       org_dns is the name server of 'org' domain while root_dns is a root
+       name server."""
+
+    def build(self, *args, **kwargs):
+        """
+                             +--------+
+                             | server |
+                             +---+----+
+                                 |
+                              +--+-+
+                        +-----+ r1 +-----+
+                        |     +----+     |
+        +-------+     +-+--+          +--+-+     +--------+
+        | slave +-----+ r2 +----------+ r3 +-----+ master |
+        +-------+     +-+--+          +--+-+     +--------+
+                        |                |
+        +--------+    +-+--+          +--+-+     +---------+
+        | orgdns +----+ r4 +----------+ r5 +-----+ rootdns |
+        +--------+    +----+          +----+     +---------+
+        """
+        # Add routers
+
+        r1, r2, r3, r4, r5 = self.addRouters('r1', 'r2', 'r3', 'r4', 'r5')
+        self.addLinks((r1, r2), (r1, r3), (r3, r2), (r2, r4), (r3, r5),
+                      (r4, r5))
+
+        # Add hosts
+        server = self.addHost('server')
+        self.addLink(r1, server)
+
+        master = self.addHost('master')
+        master.addDaemon(Named)
+        self.addLink(r3, master)
+
+        slave = self.addHost('slave')
+        slave.addDaemon(Named)
+        self.addLink(r2, slave)
+
+        orgdns = self.addHost('orgdns')
+        orgdns.addDaemon(Named)
+        self.addLink(r4, orgdns)
+
+        rootdns = self.addHost('rootdns')
+        rootdns.addDaemon(Named)
+        self.addLink(r5, rootdns)
+
+        # Declare the mydomain.org, org and root DNS zones.
+        # The orgdns server will have the NS records for 'mydomain.org' zone
+        # and the rootdns server will have the NS records for the 'org' zone.
+        self.addDNSZone(name="mydomain.org", dns_master=master,
+                        dns_slaves=[slave], nodes=[server])
+        self.addDNSZone(name="org", dns_master=orgdns)
+        self.addDNSZone(name="", dns_master=rootdns)
+
+        super().build(*args, **kwargs)

--- a/ipmininet/host/config/named.py
+++ b/ipmininet/host/config/named.py
@@ -38,6 +38,7 @@ class Named(HostDaemon):
     def __init__(self, node, **kwargs):
         # Check if apparmor is enabled in the distribution
         self.apparmor = has_cmd("aa-exec")
+        self.additional_zone_filenames = []
         super().__init__(node, **kwargs)
 
     @property
@@ -210,19 +211,21 @@ class Named(HostDaemon):
         super().set_defaults(defaults)
 
     def zone_filename(self, domain_name: str) -> str:
-        return self._file(suffix='%s.cfg' % domain_name)
+        return self._file(suffix='%szone.cfg' % domain_name)
 
     @property
     def cfg_filenames(self):
         return super().cfg_filenames + \
                [self.zone_filename(z.name)
-                for z in self._node.get('dns_zones', [])]
+                for z in self._node.get('dns_zones', [])] + \
+               self.additional_zone_filenames
 
     @property
     def template_filenames(self):
         return super().template_filenames + \
                ["%s-zone.mako" % self.NAME
-                for _ in self._node.get('dns_zones', [])]
+                for _ in self._node.get('dns_zones', []) +
+                self.additional_zone_filenames]
 
 
 class DNSRecord:

--- a/ipmininet/host/config/named.py
+++ b/ipmininet/host/config/named.py
@@ -179,11 +179,10 @@ class Named(HostDaemon):
         for zone in cfg_zones.values():
             if is_reverse_zone(zone.name):
                 continue
-            for record in zone.soa_record.records:
-                if record.rtype == "NS" \
+            for record in zone.records:
+                if isinstance(record, NSRecord) \
                         and self._node.name in record.name_server:
-                    ns_record = NSRecord(record.domain_name, self._node.name)
-                    ns_record.domain_name = domain_name
+                    ns_record = NSRecord("@", record.name_server)
         if ns_record is None:
             lg.warning("Cannot forge a DNS reverse zone because there is no"
                        " NS Record for this node in regular zones.\n")

--- a/ipmininet/host/config/named.py
+++ b/ipmininet/host/config/named.py
@@ -132,7 +132,8 @@ class Named(HostDaemon):
             # Try to place the rest in existing reverse DNS zones
             found = False
             for zone in cfg_zones.values():
-                if zone.name in record.domain_name:
+                if zone.name in record.domain_name \
+                        and is_reverse_zone(zone.name):
                     zone.soa_record.records.append(record)
                     found = True
                     break

--- a/ipmininet/host/config/named.py
+++ b/ipmininet/host/config/named.py
@@ -106,7 +106,7 @@ class Named(HostDaemon):
         that is added to cfg_zones dictionary.
         """
         # Build PTR records
-        ptr_records = []
+        ptr_records = set()
         for zone in cfg_zones.values():
             for record in zone.soa_record.records:
                 if record.rtype != "A" and record.rtype != "AAAA":
@@ -116,8 +116,8 @@ class Named(HostDaemon):
                     domain_name = record.domain_name
                 else:
                     domain_name = dns_join_name(record.domain_name, zone.name)
-                ptr_records.append(PTRRecord(record.address, domain_name,
-                                             ttl=record.ttl))
+                ptr_records.add(PTRRecord(record.address, domain_name,
+                                          ttl=record.ttl))
 
         existing_records = [record for zone in cfg_zones.values()
                             for record in zone.soa_record.records
@@ -250,6 +250,9 @@ class DNSRecord:
         return self.rtype == other.rtype \
                and self.domain_name == other.domain_name \
                and self.rdata == other.rdata
+
+    def __hash__(self):
+        return hash(self.rtype) + hash(self.domain_name) + hash(self.rdata)
 
 
 class ARecord(DNSRecord):

--- a/ipmininet/host/config/templates/named-zone.mako
+++ b/ipmininet/host/config/templates/named-zone.mako
@@ -1,6 +1,8 @@
 <% zone = node.named.zones[node.current_filename] %>
+%if zone.soa_record:
 $TTL ${zone.soa_record.ttl}
 @	IN	SOA	${zone.soa_record.rdata}
+%endif
 
 %for record in zone.records:
 ${record.domain_name}   ${record.ttl}	IN	${record.rtype}	${record.rdata}

--- a/ipmininet/host/config/templates/named.mako
+++ b/ipmininet/host/config/templates/named.mako
@@ -10,7 +10,9 @@ logging {
 
 % for filename, zone in node.named.zones.items():
 zone "${zone.name}" {
-    % if zone.master:
+    % if zone.soa_record is None:
+    type hint;
+    % elif zone.master:
     type master;
     % else:
     type slave;

--- a/ipmininet/tests/utils.py
+++ b/ipmininet/tests/utils.py
@@ -236,7 +236,7 @@ def assert_dns_record(node: IPNode, dns_server_address: str, record: DNSRecord,
     server_cmd = "dig @{address} -p {port} -t {rtype} {domain_name}"\
         .format(address=dns_server_address, rtype=record.rtype,
                 domain_name=record.domain_name, port=port)
-    out_regex = re.compile(r" *{name}[ \t]+{ttl}[ \t]+IN[ \t]+{rtype}[ \t]+"
+    out_regex = re.compile(r" *{name}.?[ \t]+{ttl}[ \t]+IN[ \t]+{rtype}[ \t]+"
                            r"{rdata}"
                            .format(rtype=record.rtype, ttl=record.ttl,
                                    name=record.domain_name,


### PR DESCRIPTION
Fixes #79 

There are two main changes:

1. This makes DNS servers domain automatically delegate subdomains
authority to the appropriate zone if it exists. This behavior can be
disabled and custom zones can be delegated as well.

2. This adds to DNS servers a hint zone for the root domain if defined.
This hint zone has records for the DNS root servers. With these hints,
a client can have access to the root of the DNS from any point in the
hierarchy. This behavior can be disabled.