### PR TITLE
[build_vm] Fix checkout of ipmininet branch

### DIFF
--- a/ipmininet/install/build_vm.sh
+++ b/ipmininet/install/build_vm.sh
@@ -37,7 +37,11 @@ sudo apt remove -yq python3-pip
 
 [ ! -d "$IPMN_DIR" ] && git clone ${IPMN_REPO} ${IPMN_DIR}
 pushd ${IPMN_DIR}
-git checkout -B ${IPMN_BRANCH} -t origin/${IPMN_BRANCH}
+git checkout -B ${IPMN_BRANCH} -t origin/${IPMN_BRANCH} || >&2 cat <<-EOF
+	WARN: Command 'git checkout -B ${IPMN_BRANCH} -t origin/${IPMN_BRANCH}' failed.
+	Please check the ipmininet repository.
+EOF
+
 sudo pip3 install .
 sudo python3 -m ipmininet.install -af6
 popd

--- a/ipmininet/install/build_vm.sh
+++ b/ipmininet/install/build_vm.sh
@@ -37,7 +37,7 @@ sudo apt remove -yq python3-pip
 
 [ ! -d "$IPMN_DIR" ] && git clone ${IPMN_REPO} ${IPMN_DIR}
 pushd ${IPMN_DIR}
-git checkout -t origin/${IPMN_BRANCH}
+git checkout -B ${IPMN_BRANCH} -t origin/${IPMN_BRANCH}
 sudo pip3 install .
 sudo python3 -m ipmininet.install -af6
 popd


### PR DESCRIPTION
The build script fails when checking out an existing branch with
following message: 'fatal: A branch named 'master' already exists.'

Use git's -B option that works also when the branch already exists.