### PR TITLE
Implement automatic logdir creation for daemons

### DIFF
--- a/docs/daemons.rst
+++ b/docs/daemons.rst
@@ -251,11 +251,46 @@ It also takes the same parameter (see previous section for details):
 OpenR
 -----
 
-The OpenR daemon can be tuned by adding keyword arguments to ``router.addDaemon(OpenR, **kargs)``.
-Here is a list of the parameters:
+The OpenR daemon can be tuned by adding keyword arguments to
+``router.addDaemon(Openr, **kargs)``.  Here is a list of the parameters:
 
 .. automethod:: ipmininet.router.config.openrd.OpenrDaemon._defaults
     :noindex:
+
+At the moment IPMininet supports OpenR release `rc-20190419-11514
+<https://github.com/facebook/openr/releases/tag/rc-20190419-11514>`_. This
+release can be build from the script
+``install/build_openr-rc-20190419-11514.sh``.
+
+As of ``rc-20190419-11514`` the OpenR daemon creates `ZeroMQ
+<https://zeromq.org>`_ sockets in ``/tmp``. Therefore, it is advisable for
+networks with several OpenR daemons to isolate the ``/tmp`` folder within Linux
+namespaces. ``OpenrRouter`` utilizes Mininet's ``privateDirs`` option to
+provide this isolation. We can pass the ``cls`` option to ``addRouter`` to
+select custom router classes:
+
+.. testcode:: OpenR
+
+    from ipmininet.iptopo import IPTopo
+    from ipmininet.router import OpenrRouter
+    from ipmininet.node_description import OpenrRouterDescription
+
+
+    class SimpleOpenrNet(IPTopo):
+
+        def build(self, *args, **kwargs):
+            r1 = self.addRouter('r1',
+                                cls=OpenrRouter,
+                                routerDescription=OpenrRouterDescription)
+            r1.addOpenrDaemon()
+
+            r2 = self.addRouter('r2',
+                                cls=OpenrRouter,
+                                routerDescription=OpenrRouterDescription)
+            r2.addOpenrDaemon()
+            self.addLink(r1, r2)
+
+            super().build(*args, **kwargs)
 
 
 OSPF

--- a/docs/daemons.rst
+++ b/docs/daemons.rst
@@ -276,7 +276,7 @@ select custom router classes:
     from ipmininet.node_description import OpenrRouterDescription
 
 
-    class SimpleOpenrNet(IPTopo):
+    class MyTopology(IPTopo):
 
         def build(self, *args, **kwargs):
             r1 = self.addRouter('r1',

--- a/ipmininet/examples/README.md
+++ b/ipmininet/examples/README.md
@@ -280,9 +280,9 @@ _topo name_ : simple_openr_network
 _args_ : n/a
 
 This network represents a small OpenR network connecting three routers in a Bus
-topology. Each router has hosts attached. The `/tmp` folders are private to
-isolate the unix sockets used by OpenR. The private `/var/log` directories
-isolate logs.
+topology. Each router has hosts attached. OpenR routers use private `/tmp`
+folders to isolate the ZMQ sockets used by the daemon. The OpenR logs are by
+default available in the host machine at `/var/tmp/log/<NODE_NAME>`.
 
 Use
 [breeze](https://github.com/facebook/openr/blob/master/openr/docs/Breeze.md) to

--- a/ipmininet/examples/simple_openr_network.py
+++ b/ipmininet/examples/simple_openr_network.py
@@ -1,16 +1,11 @@
 """This file contains a simple OpenR topology"""
 
 from ipmininet.iptopo import IPTopo
-from ipmininet.router.config import RouterConfig, Openr
+from ipmininet.router import OpenrRouter
+from ipmininet.node_description import OpenrRouterDescription
+from ipmininet.router.config import OpenrConfig
 
 HOSTS_PER_ROUTER = 2
-
-
-class OpenrConfig(RouterConfig):
-    """A simple config with only a OpenR daemon"""
-    def __init__(self, node, *args, **kwargs):
-        defaults = {}
-        super().__init__(node, daemons=((Openr, defaults),), *args, **kwargs)
 
 
 class SimpleOpenrNet(IPTopo):
@@ -25,8 +20,11 @@ class SimpleOpenrNet(IPTopo):
     """
 
     def build(self, *args, **kwargs):
-        r1, r2, r3 = self.addRouters('r1', 'r2', 'r3', config=OpenrConfig,
-                                     privateDirs=['/tmp', '/var/log'])
+        r1, r2, r3 = \
+            self.addRouters('r1', 'r2', 'r3',
+                            cls=OpenrRouter,
+                            routerDescription=OpenrRouterDescription,
+                            config=OpenrConfig)
         self.addLinks((r1, r2), (r1, r3))
         for r in (r1, r2, r3):
             for i in range(HOSTS_PER_ROUTER):

--- a/ipmininet/examples/simple_openr_network.py
+++ b/ipmininet/examples/simple_openr_network.py
@@ -3,7 +3,7 @@
 from ipmininet.iptopo import IPTopo
 from ipmininet.router import OpenrRouter
 from ipmininet.node_description import OpenrRouterDescription
-from ipmininet.router.config import OpenrConfig
+from ipmininet.router.config import OpenrRouterConfig
 
 HOSTS_PER_ROUTER = 2
 
@@ -24,7 +24,7 @@ class SimpleOpenrNet(IPTopo):
             self.addRouters('r1', 'r2', 'r3',
                             cls=OpenrRouter,
                             routerDescription=OpenrRouterDescription,
-                            config=OpenrConfig)
+                            config=OpenrRouterConfig)
         self.addLinks((r1, r2), (r1, r3))
         for r in (r1, r2, r3):
             for i in range(HOSTS_PER_ROUTER):

--- a/ipmininet/examples/simple_openr_network.py
+++ b/ipmininet/examples/simple_openr_network.py
@@ -20,15 +20,16 @@ class SimpleOpenrNet(IPTopo):
     """
 
     def build(self, *args, **kwargs):
-        r1, r2, r3 = \
-            self.addRouters('r1', 'r2', 'r3',
+        # pylint: disable=unbalanced-tuple-unpacking
+        r_1, r_2, r_3 = \
+            self.addRouters('r_1', 'r_2', 'r_3',
                             cls=OpenrRouter,
                             routerDescription=OpenrRouterDescription,
                             config=OpenrRouterConfig)
-        self.addLinks((r1, r2), (r1, r3))
-        for r in (r1, r2, r3):
+        self.addLinks((r_1, r_2), (r_1, r_3))
+        for router in (r_1, r_2, r_3):
             for i in range(HOSTS_PER_ROUTER):
-                self.addLink(r, self.addHost('h%s%s' % (i, r)),
+                self.addLink(router, self.addHost('h%s%s' % (i, router)),
                              params2={'v4_width': 5})
 
         super().build(*args, **kwargs)

--- a/ipmininet/iptopo.py
+++ b/ipmininet/iptopo.py
@@ -1,15 +1,14 @@
 """This module defines topology class that supports adding L3 routers"""
 import itertools
-from typing import Union, Type, Dict, List, Optional, Tuple, Any
+from typing import Union, Type, Dict, List, Tuple, Any
 
 from mininet.topo import Topo
 from mininet.log import lg
 
 from ipmininet.overlay import Overlay, Subnet
 from ipmininet.utils import get_set, is_container
-from ipmininet.node_description import NodeDescription, RouterDescription,\
-    HostDescription, LinkDescription
-from ipmininet.router import Router
+from ipmininet.node_description import RouterDescription, HostDescription,\
+    LinkDescription
 from ipmininet.router.config import BasicRouterConfig, OSPFArea, AS,\
     iBGPFullMesh, OpenrDomain
 from ipmininet.router.config.base import Daemon, NodeConfig

--- a/ipmininet/node_description.py
+++ b/ipmininet/node_description.py
@@ -2,7 +2,7 @@ import functools
 from typing import Union, Type, Dict, List, Optional, Tuple, Any
 
 from ipmininet.router.config.base import Daemon, NodeConfig, RouterConfig
-from ipmininet.router.config import BasicRouterConfig, OpenrDaemon, OpenrConfig
+from ipmininet.router.config import BasicRouterConfig, OpenrDaemon, OpenrRouterConfig
 from ipmininet.host.config import HostConfig
 
 class NodeDescription(str):
@@ -48,7 +48,8 @@ class RouterDescription(NodeDescription):
 
 class OpenrRouterDescription(RouterDescription):
     def addOpenrDaemon(self, daemon: Union[OpenrDaemon, Type[OpenrDaemon]],
-                       default_cfg_class: Type[OpenrConfig] = OpenrConfig,
+                       default_cfg_class: Type[OpenrRouterConfig] = \
+                           OpenrRouterConfig,
                        **kwargs):
         super().addDaemon(daemon,
                           default_cfg_class=default_cfg_class,

--- a/ipmininet/node_description.py
+++ b/ipmininet/node_description.py
@@ -1,0 +1,119 @@
+import functools
+from typing import Union, Type, Dict, List, Optional, Tuple, Any
+
+from ipmininet.router.config.base import Daemon, NodeConfig, RouterConfig
+from ipmininet.router.config import BasicRouterConfig
+from ipmininet.host.config import HostConfig
+
+class NodeDescription(str):
+
+    def __new__(cls, value, *args, **kwargs):
+        return super().__new__(cls, value)
+
+    def __init__(self, o, topo: Optional['IPTopo'] = None):
+        self.topo = topo
+        super().__init__()
+
+    def addDaemon(self, daemon: Union[Daemon, Type[Daemon]],
+                  default_cfg_class: Type[NodeConfig] = BasicRouterConfig,
+                  cfg_daemon_list="daemons", **daemon_params):
+        """Add the daemon to the list of daemons to start on the node.
+
+        :param daemon: daemon class
+        :param default_cfg_class: config class to use
+            if there is no configuration class defined for the router yet.
+        :param cfg_daemon_list: name of the parameter containing
+            the list of daemons in your config class constructor.
+            For instance, RouterConfig uses 'daemons'
+            but BasicRouterConfig uses 'additional_daemons'.
+        :param daemon_params: all the parameters to give
+            when instantiating the daemon class."""
+        if self.topo is None:
+            return
+        self.topo.addDaemon(self, daemon, default_cfg_class=default_cfg_class,
+                            cfg_daemon_list=cfg_daemon_list, **daemon_params)
+
+    def get_config(self, daemon: Union[Daemon, Type[Daemon]], **kwargs):
+        if self.topo is None:
+            return
+        return daemon.get_config(topo=self.topo, node=self, **kwargs)
+
+
+class RouterDescription(NodeDescription):
+    def addDaemon(self, daemon: Union[Daemon, Type[Daemon]],
+                  default_cfg_class: Type[RouterConfig] = BasicRouterConfig,
+                  **kwargs):
+        super(RouterDescription, self)\
+            .addDaemon(daemon, default_cfg_class=default_cfg_class, **kwargs)
+
+
+class HostDescription(NodeDescription):
+
+    def addDaemon(self, daemon: Union[Daemon, Type[Daemon]],
+                  default_cfg_class: Type[HostConfig] = HostConfig, **kwargs):
+        super(HostDescription, self)\
+            .addDaemon(daemon, default_cfg_class=default_cfg_class, **kwargs)
+
+
+@functools.total_ordering
+class LinkDescription:
+
+    def __init__(self, topo: 'IPTopo', src: str, dst: str, key, link_attrs: Dict):
+        self.src = src
+        self.dst = dst
+        self.key = key
+        self.link_attrs = link_attrs
+        self.src_intf = IntfDescription(self.src, topo, self,
+                                        self.link_attrs.setdefault("params1",
+                                                                   {}))
+        self.dst_intf = IntfDescription(self.dst, topo, self,
+                                        self.link_attrs.setdefault("params2",
+                                                                   {}))
+        super().__init__()
+
+    def __getitem__(self, item):
+        if isinstance(item, int):
+            if item == 0:
+                return self.src_intf
+            if item == 1:
+                return self.dst_intf
+            if item == 3:
+                return self.key
+            raise IndexError("Links have only two nodes and one key")
+
+        if item == self.src:
+            return self.src_intf
+        if item == self.dst:
+            return self.dst_intf
+        raise KeyError("Node '%s' is not on this link" % item)
+
+    # The following methods allow this object to behave like an edge key
+    # for mininet.topo.MultiGraph
+
+    def __hash__(self):
+        return self.key.__hash__()
+
+    def __eq__(self, other):
+        return self.key == other
+
+    def __lt__(self, other):
+        return self.key.__lt__(other)
+
+
+class IntfDescription(NodeDescription):
+
+    def __init__(self, o: str, topo: 'IPTopo', link: LinkDescription,
+                 intf_attrs: Dict):
+        self.link = link
+        self.node = o
+        self.intf_attrs = intf_attrs
+        super().__init__(o, topo)
+
+    def addParams(self, **kwargs):
+        self.intf_attrs.update(kwargs)
+
+    def __hash__(self):
+        return self.node.__hash__()
+
+    def __eq__(self, other):
+        return self.node.__eq__(other)

--- a/ipmininet/node_description.py
+++ b/ipmininet/node_description.py
@@ -1,10 +1,11 @@
 import functools
-from typing import Union, Type, Dict, List, Optional, Tuple, Any
+from typing import Union, Type, Dict, Optional
 
 from ipmininet.router.config.base import Daemon, NodeConfig, RouterConfig
 from ipmininet.router.config import BasicRouterConfig, OpenrDaemon, Openr, \
     OpenrRouterConfig
 from ipmininet.host.config import HostConfig
+
 
 class NodeDescription(str):
     def __new__(cls, value, *args, **kwargs):
@@ -12,6 +13,7 @@ class NodeDescription(str):
 
     def __init__(self, o, topo: Optional['IPTopo'] = None):
         self.topo = topo
+        self.node = o
         super().__init__()
 
     def addDaemon(self, daemon: Union[Daemon, Type[Daemon]],
@@ -43,14 +45,15 @@ class RouterDescription(NodeDescription):
     def addDaemon(self, daemon: Union[Daemon, Type[Daemon]],
                   default_cfg_class: Type[RouterConfig] = BasicRouterConfig,
                   **kwargs):
-        super(RouterDescription, self)\
-            .addDaemon(daemon, default_cfg_class=default_cfg_class, **kwargs)
+        super().addDaemon(daemon,
+                          default_cfg_class=default_cfg_class,
+                          **kwargs)
 
 
 class OpenrRouterDescription(RouterDescription):
     def addOpenrDaemon(self,
                        daemon: Union[OpenrDaemon, Type[OpenrDaemon]] = Openr,
-                       default_cfg_class: Type[OpenrRouterConfig] = \
+                       default_cfg_class: Type[OpenrRouterConfig] =
                            OpenrRouterConfig,
                        **kwargs):
         self.addDaemon(daemon,
@@ -61,13 +64,19 @@ class OpenrRouterDescription(RouterDescription):
 class HostDescription(NodeDescription):
     def addDaemon(self, daemon: Union[Daemon, Type[Daemon]],
                   default_cfg_class: Type[HostConfig] = HostConfig, **kwargs):
-        super(HostDescription, self)\
-            .addDaemon(daemon, default_cfg_class=default_cfg_class, **kwargs)
+        super().addDaemon(daemon,
+                          default_cfg_class=default_cfg_class,
+                          **kwargs)
 
 
 @functools.total_ordering
 class LinkDescription:
-    def __init__(self, topo: 'IPTopo', src: str, dst: str, key, link_attrs: Dict):
+    def __init__(self,
+                 topo: 'IPTopo',
+                 src: str,
+                 dst: str,
+                 key,
+                 link_attrs: Dict):
         self.src = src
         self.dst = dst
         self.key = key
@@ -113,7 +122,6 @@ class IntfDescription(NodeDescription):
     def __init__(self, o: str, topo: 'IPTopo', link: LinkDescription,
                  intf_attrs: Dict):
         self.link = link
-        self.node = o
         self.intf_attrs = intf_attrs
         super().__init__(o, topo)
 

--- a/ipmininet/node_description.py
+++ b/ipmininet/node_description.py
@@ -2,7 +2,8 @@ import functools
 from typing import Union, Type, Dict, List, Optional, Tuple, Any
 
 from ipmininet.router.config.base import Daemon, NodeConfig, RouterConfig
-from ipmininet.router.config import BasicRouterConfig, OpenrDaemon, OpenrRouterConfig
+from ipmininet.router.config import BasicRouterConfig, OpenrDaemon, Openr, \
+    OpenrRouterConfig
 from ipmininet.host.config import HostConfig
 
 class NodeDescription(str):
@@ -47,7 +48,8 @@ class RouterDescription(NodeDescription):
 
 
 class OpenrRouterDescription(RouterDescription):
-    def addOpenrDaemon(self, daemon: Union[OpenrDaemon, Type[OpenrDaemon]],
+    def addOpenrDaemon(self,
+                       daemon: Union[OpenrDaemon, Type[OpenrDaemon]] = Openr,
                        default_cfg_class: Type[OpenrRouterConfig] = \
                            OpenrRouterConfig,
                        **kwargs):

--- a/ipmininet/node_description.py
+++ b/ipmininet/node_description.py
@@ -48,9 +48,9 @@ class RouterDescription(NodeDescription):
 
 
 class OpenrRouterDescription(RouterDescription):
-    def addDaemon(self, daemon: Union[OpenrDaemon, Type[OpenrDaemon]],
-                  default_cfg_class: Type[OpenrConfig] = OpenrConfig,
-                  **kwargs):
+    def addOpenrDaemon(self, daemon: Union[OpenrDaemon, Type[OpenrDaemon]],
+                       default_cfg_class: Type[OpenrConfig] = OpenrConfig,
+                       **kwargs):
         super().addDaemon(daemon,
                           default_cfg_class=default_cfg_class,
                           **kwargs)

--- a/ipmininet/node_description.py
+++ b/ipmininet/node_description.py
@@ -51,11 +51,12 @@ class RouterDescription(NodeDescription):
 
 
 class OpenrRouterDescription(RouterDescription):
-    def addOpenrDaemon(self,
-                       daemon: Union[OpenrDaemon, Type[OpenrDaemon]] = Openr,
-                       default_cfg_class: Type[OpenrRouterConfig] =
-                           OpenrRouterConfig,
-                       **kwargs):
+    def addOpenrDaemon(
+            self,
+            daemon: Union[OpenrDaemon, Type[OpenrDaemon]] = Openr,
+            default_cfg_class: Type[OpenrRouterConfig] = OpenrRouterConfig,
+            **kwargs
+    ):
         self.addDaemon(daemon,
                        default_cfg_class=default_cfg_class,
                        **kwargs)

--- a/ipmininet/node_description.py
+++ b/ipmininet/node_description.py
@@ -6,7 +6,6 @@ from ipmininet.router.config import BasicRouterConfig, OpenrDaemon, OpenrConfig
 from ipmininet.host.config import HostConfig
 
 class NodeDescription(str):
-
     def __new__(cls, value, *args, **kwargs):
         return super().__new__(cls, value)
 
@@ -57,7 +56,6 @@ class OpenrRouterDescription(RouterDescription):
 
 
 class HostDescription(NodeDescription):
-
     def addDaemon(self, daemon: Union[Daemon, Type[Daemon]],
                   default_cfg_class: Type[HostConfig] = HostConfig, **kwargs):
         super(HostDescription, self)\
@@ -66,7 +64,6 @@ class HostDescription(NodeDescription):
 
 @functools.total_ordering
 class LinkDescription:
-
     def __init__(self, topo: 'IPTopo', src: str, dst: str, key, link_attrs: Dict):
         self.src = src
         self.dst = dst
@@ -110,7 +107,6 @@ class LinkDescription:
 
 
 class IntfDescription(NodeDescription):
-
     def __init__(self, o: str, topo: 'IPTopo', link: LinkDescription,
                  intf_attrs: Dict):
         self.link = link

--- a/ipmininet/node_description.py
+++ b/ipmininet/node_description.py
@@ -2,7 +2,7 @@ import functools
 from typing import Union, Type, Dict, List, Optional, Tuple, Any
 
 from ipmininet.router.config.base import Daemon, NodeConfig, RouterConfig
-from ipmininet.router.config import BasicRouterConfig
+from ipmininet.router.config import BasicRouterConfig, OpenrDaemon, OpenrConfig
 from ipmininet.host.config import HostConfig
 
 class NodeDescription(str):
@@ -45,6 +45,15 @@ class RouterDescription(NodeDescription):
                   **kwargs):
         super(RouterDescription, self)\
             .addDaemon(daemon, default_cfg_class=default_cfg_class, **kwargs)
+
+
+class OpenrRouterDescription(RouterDescription):
+    def addDaemon(self, daemon: Union[OpenrDaemon, Type[OpenrDaemon]],
+                  default_cfg_class: Type[OpenrConfig] = OpenrConfig,
+                  **kwargs):
+        super().addDaemon(daemon,
+                          default_cfg_class=default_cfg_class,
+                          **kwargs)
 
 
 class HostDescription(NodeDescription):

--- a/ipmininet/node_description.py
+++ b/ipmininet/node_description.py
@@ -51,9 +51,9 @@ class OpenrRouterDescription(RouterDescription):
                        default_cfg_class: Type[OpenrRouterConfig] = \
                            OpenrRouterConfig,
                        **kwargs):
-        super().addDaemon(daemon,
-                          default_cfg_class=default_cfg_class,
-                          **kwargs)
+        self.addDaemon(daemon,
+                       default_cfg_class=default_cfg_class,
+                       **kwargs)
 
 
 class HostDescription(NodeDescription):

--- a/ipmininet/router/__init__.py
+++ b/ipmininet/router/__init__.py
@@ -1,6 +1,6 @@
 """This module defines a modular router that is able to support
    multiple daemons
 """
-from .__router import Router, ProcessHelper, IPNode
+from .__router import Router, ProcessHelper, IPNode, OpenrRouter
 
-__all__ = ['IPNode', 'Router', 'ProcessHelper']
+__all__ = ['IPNode', 'Router', 'OpenrRouter', 'ProcessHelper']

--- a/ipmininet/router/__router.py
+++ b/ipmininet/router/__router.py
@@ -9,7 +9,7 @@ from typing import Type, Optional, Tuple, Union, Dict, List, Sequence, Set
 from ipmininet import DEBUG_FLAG
 from ipmininet.utils import L3Router, realIntfList, otherIntf
 from ipmininet.link import IPIntf
-from .config import BasicRouterConfig, NodeConfig, RouterConfig
+from .config import BasicRouterConfig, NodeConfig, RouterConfig, OpenrConfig
 
 import mininet.clean
 from mininet.node import Node, Host
@@ -207,3 +207,21 @@ class Router(IPNode, L3Router):
     @property
     def asn(self) -> int:
         return self.get('asn')
+
+
+class OpenrRouter(Router):
+    """OpenR router with private '/tmp' dir to handle unix sockets created by
+       the OpenR daemon"""
+
+    def __init__(self, name,
+                 config: Type[OpenrConfig],
+                 lo_addresses: Sequence[Union[str, IPv4Interface,
+                                              IPv6Interface]] = (),
+                 privateDirs=['/tmp'],
+                 *args, **kwargs):
+        super().__init__(name,
+                         config=config,
+                         lo_addresses=lo_addresses,
+                         password=None,
+                         privateDirs=privateDirs,
+                         *args, **kwargs)

--- a/ipmininet/router/__router.py
+++ b/ipmininet/router/__router.py
@@ -9,7 +9,7 @@ from typing import Type, Optional, Tuple, Union, Dict, List, Sequence, Set
 from ipmininet import DEBUG_FLAG
 from ipmininet.utils import L3Router, realIntfList, otherIntf
 from ipmininet.link import IPIntf
-from .config import BasicRouterConfig, NodeConfig, RouterConfig, OpenrConfig
+from .config import BasicRouterConfig, NodeConfig, RouterConfig, OpenrRouterConfig
 
 import mininet.clean
 from mininet.node import Node, Host
@@ -235,7 +235,7 @@ class OpenrRouter(Router):
        the OpenR daemon"""
 
     def __init__(self, name,
-                 config: Type[OpenrConfig],
+                 config: Type[OpenrRouterConfig],
                  lo_addresses: Sequence[Union[str, IPv4Interface,
                                               IPv6Interface]] = (),
                  privateDirs=['/tmp'],

--- a/ipmininet/router/__router.py
+++ b/ipmininet/router/__router.py
@@ -1,15 +1,15 @@
 """This modules defines a L3 router class,
    with a modular config system."""
-import subprocess
 import sys
 import time
 from ipaddress import IPv4Interface, IPv6Interface
-from typing import Type, Optional, Tuple, Union, Dict, List, Sequence, Set
+from typing import Type, Optional, Tuple, Union, Dict, List, Sequence
 
 from ipmininet import DEBUG_FLAG
 from ipmininet.utils import L3Router, realIntfList, otherIntf
 from ipmininet.link import IPIntf
-from .config import BasicRouterConfig, NodeConfig, RouterConfig, OpenrRouterConfig
+from .config import BasicRouterConfig, NodeConfig, RouterConfig, \
+    OpenrRouterConfig
 
 import mininet.clean
 from mininet.node import Node, Host
@@ -166,7 +166,7 @@ class IPNode(Node):
         """
         lg.debug('{}: Creating logdir {}.\n'.format(self.name, logdir))
         cmd = 'mkdir -p {}'.format(logdir)
-        stdout, stderr, return_code =  self._processes.pexec(shlex.split(cmd))
+        stdout, stderr, return_code = self._processes.pexec(shlex.split(cmd))
         if not return_code:
             lg.debug('{}: Logdir {} successfully created.\n'.format(self.name,
                                                                     logdir))
@@ -234,12 +234,14 @@ class OpenrRouter(Router):
     """OpenR router with private '/tmp' dir to handle unix sockets created by
        the OpenR daemon"""
 
-    def __init__(self, name,
+    def __init__(self, name, *args,
                  config: Type[OpenrRouterConfig],
-                 lo_addresses: Sequence[Union[str, IPv4Interface,
-                                              IPv6Interface]] = (),
+                 lo_addresses: Optional[Sequence[
+                     Union[str, IPv4Interface, IPv6Interface]]] = None,
                  privateDirs=['/tmp'],
-                 *args, **kwargs):
+                 **kwargs):
+        if not lo_addresses:
+            lo_addresses = ()
         super().__init__(name,
                          config=config,
                          lo_addresses=lo_addresses,

--- a/ipmininet/router/__router.py
+++ b/ipmininet/router/__router.py
@@ -110,6 +110,8 @@ class IPNode(Node):
         # Check them
         err_code = False
         for d in self.nconfig.daemons:
+            if d.logdir:
+                self._mklogdirs(d.logdir)
             out, err, code = self._processes.pexec(shlex.split(d.dry_run))
             err_code = err_code or code
             if code:
@@ -153,6 +155,23 @@ class IPNode(Node):
         if v != val:
             self._processes.call('sysctl', '-w', '%s=%s' % (key, val))
         return v
+
+    def _mklogdirs(self, logdir) -> Tuple[str, str, int]:
+        """Creates directories for the given logdir.
+
+           :param logdir: The log directory path to create
+           :return: (stdout, stderr, return_code)
+        """
+        lg.info('{}: Creating logdir {}.\n'.format(self.name, logdir))
+        cmd = 'mkdir -p {}'.format(logdir)
+        stdout, stderr, return_code =  self._processes.pexec(shlex.split(cmd))
+        if not return_code:
+            lg.info('{}: Logdir {} successfully created.\n'.format(self.name,
+                                                                    logdir))
+        else:
+            lg.warn('{}: Could not create logdir {}. Stderr: \n'
+                     '{}\n'.format(self.name, logdir, stderr))
+        return (stdout, stderr, return_code)
 
     def get(self, key, val=None):
         """Check for a given key in the node parameters"""

--- a/ipmininet/router/__router.py
+++ b/ipmininet/router/__router.py
@@ -76,6 +76,7 @@ class IPNode(Node):
                  process_manager: Type[ProcessHelper] = ProcessHelper,
                  use_v4=True,
                  use_v6=True,
+                 create_logdirs=True,
                  *args, **kwargs):
         """Most of the heavy lifting for this node should happen in the
         associated config object.
@@ -92,6 +93,7 @@ class IPNode(Node):
         self.use_v6 = use_v6
         self.cwd = cwd
         self._old_sysctl = {}  # type: Dict[str, Union[str, int]]
+        self.create_logdirs = create_logdirs
         if isinstance(config, tuple):
             try:
                 self.nconfig = config[0](self, **config[1])
@@ -110,7 +112,7 @@ class IPNode(Node):
         # Check them
         err_code = False
         for d in self.nconfig.daemons:
-            if d.logdir:
+            if self.create_logdirs and d.logdir:
                 self._mklogdirs(d.logdir)
             out, err, code = self._processes.pexec(shlex.split(d.dry_run))
             err_code = err_code or code

--- a/ipmininet/router/__router.py
+++ b/ipmininet/router/__router.py
@@ -162,14 +162,14 @@ class IPNode(Node):
            :param logdir: The log directory path to create
            :return: (stdout, stderr, return_code)
         """
-        lg.info('{}: Creating logdir {}.\n'.format(self.name, logdir))
+        lg.debug('{}: Creating logdir {}.\n'.format(self.name, logdir))
         cmd = 'mkdir -p {}'.format(logdir)
         stdout, stderr, return_code =  self._processes.pexec(shlex.split(cmd))
         if not return_code:
-            lg.info('{}: Logdir {} successfully created.\n'.format(self.name,
+            lg.debug('{}: Logdir {} successfully created.\n'.format(self.name,
                                                                     logdir))
         else:
-            lg.warn('{}: Could not create logdir {}. Stderr: \n'
+            lg.error('{}: Could not create logdir {}. Stderr: \n'
                      '{}\n'.format(self.name, logdir, stderr))
         return (stdout, stderr, return_code)
 

--- a/ipmininet/router/config/__init__.py
+++ b/ipmininet/router/config/__init__.py
@@ -1,6 +1,7 @@
 """This module holds the configuration generators for daemons
 that can be used in a router."""
-from .base import BorderRouterConfig, BasicRouterConfig, RouterConfig, NodeConfig
+from .base import BorderRouterConfig, BasicRouterConfig, RouterConfig, \
+    OpenrConfig, NodeConfig
 from .zebra import Zebra
 from .staticd import STATIC, StaticRoute
 from .ospf import OSPF, OSPFArea
@@ -24,7 +25,7 @@ __all__ = ['BasicRouterConfig', 'NodeConfig', 'Zebra', 'OSPF', 'OSPF6',
            'ebgp_session', 'CommunityList', 'set_rr', 'AccessList', 'IPTables',
            'IP6Tables', 'SSHd', 'RADVD', 'AdvPrefix', 'AdvConnectedPrefix',
            'AdvRDNSS', 'PIMD', 'RIPng', 'STATIC', 'StaticRoute',
-           'OpenrDaemon', 'Openr', 'OpenrDomain', 'AF_INET', 'AF_INET6',
-           'BorderRouterConfig', 'Rule', 'Chain', 'ChainRule', 'NOT',
-           'PortClause', 'InterfaceClause', 'AddressClause', 'Filter',
+           'OpenrDaemon', 'Openr', 'OpenrConfig', 'OpenrDomain', 'AF_INET',
+           'AF_INET6', 'BorderRouterConfig', 'Rule', 'Chain', 'ChainRule',
+           'NOT', 'PortClause', 'InterfaceClause', 'AddressClause', 'Filter',
            'InputFilter', 'OutputFilter', 'TransitFilter', 'Allow', 'Deny']

--- a/ipmininet/router/config/__init__.py
+++ b/ipmininet/router/config/__init__.py
@@ -1,7 +1,7 @@
 """This module holds the configuration generators for daemons
 that can be used in a router."""
 from .base import BorderRouterConfig, BasicRouterConfig, RouterConfig, \
-    OpenrConfig, NodeConfig
+    OpenrRouterConfig, NodeConfig
 from .zebra import Zebra
 from .staticd import STATIC, StaticRoute
 from .ospf import OSPF, OSPFArea
@@ -25,7 +25,8 @@ __all__ = ['BasicRouterConfig', 'NodeConfig', 'Zebra', 'OSPF', 'OSPF6',
            'ebgp_session', 'CommunityList', 'set_rr', 'AccessList', 'IPTables',
            'IP6Tables', 'SSHd', 'RADVD', 'AdvPrefix', 'AdvConnectedPrefix',
            'AdvRDNSS', 'PIMD', 'RIPng', 'STATIC', 'StaticRoute',
-           'OpenrDaemon', 'Openr', 'OpenrConfig', 'OpenrDomain', 'AF_INET',
-           'AF_INET6', 'BorderRouterConfig', 'Rule', 'Chain', 'ChainRule',
-           'NOT', 'PortClause', 'InterfaceClause', 'AddressClause', 'Filter',
-           'InputFilter', 'OutputFilter', 'TransitFilter', 'Allow', 'Deny']
+           'OpenrDaemon', 'Openr', 'OpenrRouterConfig', 'OpenrDomain',
+           'AF_INET', 'AF_INET6', 'BorderRouterConfig', 'Rule', 'Chain',
+           'ChainRule', 'NOT', 'PortClause', 'InterfaceClause',
+           'AddressClause', 'Filter', 'InputFilter', 'OutputFilter',
+           'TransitFilter', 'Allow', 'Deny']

--- a/ipmininet/router/config/base.py
+++ b/ipmininet/router/config/base.py
@@ -20,7 +20,7 @@ import mako.exceptions
 from mininet.log import lg as log
 
 if TYPE_CHECKING:
-    from ipmininet.router import IPNode, Router
+    from ipmininet.router import IPNode, Router, OpenrRouter
     from ipmininet.iptopo import IPTopo
     from ipmininet.node_description import NodeDescription
 DaemonOption = Union['Daemon', Type['Daemon'],
@@ -469,4 +469,21 @@ class BorderRouterConfig(BasicRouterConfig):
         if af:
             d = list(daemons)
             d.append((BGP, {'address_families': af}))
+        super().__init__(node, daemons=d, *args, **kwargs)
+
+
+class OpenrConfig(RouterConfig):
+    """A basic router that will run an OpenR daemon"""
+    def __init__(self, node: 'OpenrRouter',
+                 daemons: Iterable[DaemonOption] = (),
+                 additional_daemons: Iterable[DaemonOption] = (),
+                 *args, **kwargs):
+        """A simple router made of at least an OpenR daemon
+
+        :param additional_daemons: Other daemons that should be used"""
+        # Importing here to avoid circular import
+        from .openr import Openr
+        d = list(daemons)
+        d.append(Openr)
+        d.extend(additional_daemons)
         super().__init__(node, daemons=d, *args, **kwargs)

--- a/ipmininet/router/config/base.py
+++ b/ipmininet/router/config/base.py
@@ -291,6 +291,13 @@ class Daemon(metaclass=abc.ABCMeta):
         """Get the options ConfigDict for this daemon"""
         return self._options
 
+    @property
+    def logdir(self) -> str:
+        if 'logfile' in self._options:
+            return os.path.dirname(self._options['logfile'])
+        else:
+            return None
+
     def build(self) -> ConfigDict:
         """Build the configuration tree for this daemon
 

--- a/ipmininet/router/config/base.py
+++ b/ipmininet/router/config/base.py
@@ -479,7 +479,7 @@ class BorderRouterConfig(BasicRouterConfig):
         super().__init__(node, daemons=d, *args, **kwargs)
 
 
-class OpenrConfig(RouterConfig):
+class OpenrRouterConfig(RouterConfig):
     """A basic router that will run an OpenR daemon"""
     def __init__(self, node: 'OpenrRouter',
                  daemons: Iterable[DaemonOption] = (),

--- a/ipmininet/router/config/base.py
+++ b/ipmininet/router/config/base.py
@@ -21,7 +21,8 @@ from mininet.log import lg as log
 
 if TYPE_CHECKING:
     from ipmininet.router import IPNode, Router
-    from ipmininet.iptopo import IPTopo, NodeDescription
+    from ipmininet.iptopo import IPTopo
+    from ipmininet.node_description import NodeDescription
 DaemonOption = Union['Daemon', Type['Daemon'],
                      Tuple[Union['Daemon', Type['Daemon']], Dict]]
 

--- a/ipmininet/router/config/base.py
+++ b/ipmininet/router/config/base.py
@@ -295,8 +295,7 @@ class Daemon(metaclass=abc.ABCMeta):
     def logdir(self) -> str:
         if 'logfile' in self._options:
             return os.path.dirname(self._options['logfile'])
-        else:
-            return None
+        return None
 
     def build(self) -> ConfigDict:
         """Build the configuration tree for this daemon
@@ -490,7 +489,7 @@ class OpenrRouterConfig(RouterConfig):
         :param additional_daemons: Other daemons that should be used"""
         # Importing here to avoid circular import
         from .openr import Openr
-        d = list(daemons)
-        d.append(Openr)
-        d.extend(additional_daemons)
-        super().__init__(node, daemons=d, *args, **kwargs)
+        daemon_list = list(daemons)
+        daemon_list.append(Openr)
+        daemon_list.extend(additional_daemons)
+        super().__init__(node, daemons=daemon_list, *args, **kwargs)

--- a/ipmininet/router/config/bgp.py
+++ b/ipmininet/router/config/bgp.py
@@ -13,7 +13,8 @@ from .zebra import QuaggaDaemon, Zebra, RouteMap, AccessList, \
     RouteMapMatchCond, CommunityList, RouteMapSetAction, PERMIT, DENY
 
 if TYPE_CHECKING:
-    from ipmininet.iptopo import IPTopo, RouterDescription
+    from ipmininet.iptopo import IPTopo
+    from ipmininet.node_description import RouterDescription
     from ipmininet.router import Router
 
 

--- a/ipmininet/router/config/openr.py
+++ b/ipmininet/router/config/openr.py
@@ -49,7 +49,10 @@ class Openr(OpenrDaemon):
 
     def build(self):
         cfg = super().build()
+        self.options.redistribute_ifaces = \
+            ','.join([intf.name for intf in self._node.intfList()])
         cfg.update(self.options)
+        cfg.redistribute_ifaces = \
         self._create_log_dir()
         interfaces = realIntfList(self._node)
         cfg.interfaces = self._build_interfaces(interfaces)

--- a/ipmininet/router/config/openr.py
+++ b/ipmininet/router/config/openr.py
@@ -86,7 +86,9 @@ class Openr(OpenrDaemon):
         defaults.node_name = self._node.name
         defaults.ifname_prefix = '{}-eth'.format(self._node.name)
         defaults.iface_regex_include = '{}-eth.*'.format(self._node.name)
-        defaults.log_dir = "/var/log"
+        defaults.log_dir = '/tmp/log/{}'.format(self._node.name)
+        defaults.config_store_filepath = \
+            '/tmp/{}_aq_persistent_config_store.bin'.format(self._node.name)
         super().set_defaults(defaults)
 
     @staticmethod

--- a/ipmininet/router/config/openr.py
+++ b/ipmininet/router/config/openr.py
@@ -86,7 +86,7 @@ class Openr(OpenrDaemon):
         for itf in interfaces:
             ipv6_addresses += itf.addresses[6]
         ipv6_addresses = filter(lambda x: not x.is_link_local, ipv6_addresses)
-        return ",".join(map(lambda x: x.with_prefixlen, ipv6_addresses))
+        return ','.join(map(lambda x: x.with_prefixlen, ipv6_addresses))
 
     def set_defaults(self, defaults):
         """Updates some options of the OpenR daemon to run a network of

--- a/ipmininet/router/config/openr.py
+++ b/ipmininet/router/config/openr.py
@@ -1,6 +1,4 @@
 """Base classes to configure an OpenR daemon"""
-import os
-
 from ipaddress import ip_interface
 
 from mininet.log import lg as log
@@ -48,30 +46,24 @@ class Openr(OpenrDaemon):
     def __init__(self, node, *args, **kwargs):
         super().__init__(node=node, *args, **kwargs)
 
+    @property
+    def logdir(self) -> str:
+        if 'log_dir' in self._options:
+            return self._options['log_dir']
+        else:
+            return None
+
     def build(self):
         cfg = super().build()
         self.options.redistribute_ifaces = \
             ','.join([intf.name for intf in self._node.intfList()])
         cfg.update(self.options)
         cfg.redistribute_ifaces = \
-        self._mklogdirs()
         interfaces = realIntfList(self._node)
         cfg.interfaces = self._build_interfaces(interfaces)
         cfg.networks = self._build_networks(interfaces)
         cfg.prefixes = self._build_prefixes(interfaces)
         return cfg
-
-    def _mklogdirs(self):
-        try:
-            log.info('Openr: Creating log_dir for node '
-                     '{}\n'.format(self._node.name))
-            os.makedirs(self.options.log_dir)
-            log.info('Openr: Created missing directories in log_dir path '
-                     '{}\n'.format(self.options.log_dir))
-        except FileExistsError as e:
-            log.warn('Openr: Path for log_dir already exists. Using log_dir '
-                     '{}\n'.format(self.options.log_dir))
-        return self.options.log_dir
 
     @staticmethod
     def _build_networks(interfaces):

--- a/ipmininet/router/config/openr.py
+++ b/ipmininet/router/config/openr.py
@@ -3,6 +3,7 @@ import os
 
 from ipaddress import ip_interface
 
+from mininet.log import lg as log
 from ipmininet.overlay import Overlay
 from ipmininet.utils import L3Router, realIntfList
 from .utils import ConfigDict
@@ -53,15 +54,24 @@ class Openr(OpenrDaemon):
             ','.join([intf.name for intf in self._node.intfList()])
         cfg.update(self.options)
         cfg.redistribute_ifaces = \
-        self._create_log_dir()
+        self._mklogdirs()
         interfaces = realIntfList(self._node)
         cfg.interfaces = self._build_interfaces(interfaces)
         cfg.networks = self._build_networks(interfaces)
         cfg.prefixes = self._build_prefixes(interfaces)
         return cfg
 
-    def _create_log_dir(self):
-        os.makedirs(self.options.log_dir, exist_ok=True)
+    def _mklogdirs(self):
+        try:
+            log.info('Openr: Creating log_dir for node '
+                     '{}\n'.format(self._node.name))
+            os.makedirs(self.options.log_dir)
+            log.info('Openr: Created missing directories in log_dir path '
+                     '{}\n'.format(self.options.log_dir))
+        except FileExistsError as e:
+            log.warn('Openr: Path for log_dir already exists. Using log_dir '
+                     '{}\n'.format(self.options.log_dir))
+        return self.options.log_dir
 
     @staticmethod
     def _build_networks(interfaces):

--- a/ipmininet/router/config/openr.py
+++ b/ipmininet/router/config/openr.py
@@ -95,9 +95,7 @@ class Openr(OpenrDaemon):
         defaults.node_name = self._node.name
         defaults.ifname_prefix = '{}-eth'.format(self._node.name)
         defaults.iface_regex_include = '{}-eth.*'.format(self._node.name)
-        defaults.log_dir = '/tmp/log/{}'.format(self._node.name)
-        defaults.config_store_filepath = \
-            '/tmp/{}_aq_persistent_config_store.bin'.format(self._node.name)
+        defaults.log_dir = '/var/tmp/log/{}'.format(self._node.name)
         defaults.enable_v4 = True
         super().set_defaults(defaults)
 

--- a/ipmininet/router/config/openr.py
+++ b/ipmininet/router/config/openr.py
@@ -48,7 +48,6 @@ class Openr(OpenrDaemon):
     def build(self):
         cfg = super().build()
         cfg.update(self.options)
-        cfg.node_name = self._node.name
         interfaces = realIntfList(self._node)
         cfg.interfaces = self._build_interfaces(interfaces)
         cfg.networks = self._build_networks(interfaces)
@@ -84,6 +83,7 @@ class Openr(OpenrDaemon):
         """Updates some options of the OpenR daemon to run a network of
         routers in mininet. For a full list of parameters see
         OpenrDaemon:_defaults in openrd.py"""
+        defaults.node_name = self._node.name
         defaults.ifname_prefix = "r"
         defaults.iface_regex_include = "r.*"
         defaults.log_dir = "/var/log"

--- a/ipmininet/router/config/openr.py
+++ b/ipmininet/router/config/openr.py
@@ -84,8 +84,8 @@ class Openr(OpenrDaemon):
         routers in mininet. For a full list of parameters see
         OpenrDaemon:_defaults in openrd.py"""
         defaults.node_name = self._node.name
-        defaults.ifname_prefix = "r"
-        defaults.iface_regex_include = "r.*"
+        defaults.ifname_prefix = '{}-eth'.format(self._node.name)
+        defaults.iface_regex_include = '{}-eth.*'.format(self._node.name)
         defaults.log_dir = "/var/log"
         super().set_defaults(defaults)
 

--- a/ipmininet/router/config/openr.py
+++ b/ipmininet/router/config/openr.py
@@ -95,6 +95,7 @@ class Openr(OpenrDaemon):
         defaults.log_dir = '/tmp/log/{}'.format(self._node.name)
         defaults.config_store_filepath = \
             '/tmp/{}_aq_persistent_config_store.bin'.format(self._node.name)
+        defaults.enable_v4 = True
         super().set_defaults(defaults)
 
     @staticmethod

--- a/ipmininet/router/config/openr.py
+++ b/ipmininet/router/config/openr.py
@@ -1,4 +1,6 @@
 """Base classes to configure an OpenR daemon"""
+import os
+
 from ipaddress import ip_interface
 
 from ipmininet.overlay import Overlay
@@ -48,11 +50,15 @@ class Openr(OpenrDaemon):
     def build(self):
         cfg = super().build()
         cfg.update(self.options)
+        self._create_log_dir()
         interfaces = realIntfList(self._node)
         cfg.interfaces = self._build_interfaces(interfaces)
         cfg.networks = self._build_networks(interfaces)
         cfg.prefixes = self._build_prefixes(interfaces)
         return cfg
+
+    def _create_log_dir(self):
+        os.makedirs(self.options.log_dir, exist_ok=True)
 
     @staticmethod
     def _build_networks(interfaces):

--- a/ipmininet/router/config/openrd.py
+++ b/ipmininet/router/config/openrd.py
@@ -167,7 +167,7 @@ class OpenrDaemon(RouterDaemon):
         :param redistribute_ifaces: Comma separated list of interface names
             whose '/32' (for v4) and '/128' (for v6) should be announced. OpenR
             will monitor address add/remove activity on this interface and
-            announce it to rest of the network. Default: "lo1".
+            announce it to rest of the network. Default: "lo".
         :param seed_prefix: In order to elect a prefix for the node a super
             prefix to elect from is required. This is only applicable when
             'ENABLE_PREFIX_ALLOC' is set to true. Default: "".

--- a/ipmininet/router/config/openrd.py
+++ b/ipmininet/router/config/openrd.py
@@ -232,7 +232,7 @@ class OpenrDaemon(RouterDaemon):
         """The OpenR daemon has currently no option to read config from
         configuration file itself. The run_openr.sh script can be used to read
         options from environment files. However, we want to run the daemon
-        directly.  The default options from the shell script are implemented in
+        directly. The default options from the shell script are implemented in
         the openr.mako template and passed to the daemon as argument."""
         cfg = ConfigDict()
         cfg[self.NAME] = self.build()

--- a/ipmininet/router/config/openrd.py
+++ b/ipmininet/router/config/openrd.py
@@ -235,7 +235,7 @@ class OpenrDaemon(RouterDaemon):
         directly. The default options from the shell script are implemented in
         the openr.mako template and passed to the daemon as argument."""
         cfg = ConfigDict()
-        cfg[self.NAME] = self.build()
+        cfg[self.NAME] = self.options
         return self.template_lookup.get_template(self.template_filenames[0])\
                                    .render(node=cfg)
 

--- a/ipmininet/router/config/templates/openr.mako
+++ b/ipmininet/router/config/templates/openr.mako
@@ -54,7 +54,7 @@ ${getConfig("node_name", "")} \
 ${getConfig("override_loopback_addr", False)} \
 ${getConfig("prefix_manager_cmd_port", 60011)} \
 ${getConfig("prefixes", "")} \
-${getConfig("redistribute_ifaces", "lo1")} \
+${getConfig("redistribute_ifaces", "lo")} \
 ${getConfig("seed_prefix", "")} \
 ${getConfig("set_leaf_node", False)} \
 ${getConfig("set_loopback_address", False)} \

--- a/ipmininet/tests/test_openr.py
+++ b/ipmininet/tests/test_openr.py
@@ -1,0 +1,92 @@
+import pytest
+import os
+import tempfile
+
+from ipmininet.clean import cleanup
+from ipmininet.ipnet import IPNet
+from ipmininet.iptopo import IPTopo
+from ipmininet.router import OpenrRouter
+from ipmininet.node_description import OpenrRouterDescription
+from ipmininet.router.config import OpenrRouterConfig
+from ipmininet.tests.utils import assert_connectivity
+
+from . import require_root
+
+
+class SimpleOpenrTopo(IPTopo):
+    def __init__(self, *args, **kwargs):
+        self.r4_log_dir = '/var/tmp/different/log/location'
+        super().__init__(*args, **kwargs)
+
+    def build(self, *args, **kwargs):
+        r1, r2, r3 = \
+            self.addRouters('r1', 'r2', 'r3',
+                            cls=OpenrRouter,
+                            routerDescription=OpenrRouterDescription,
+                            config=OpenrRouterConfig)
+        r4 = self.addRouter('r4', routerDescription=OpenrRouterDescription)
+        r4.addOpenrDaemon(log_dir=self.r4_log_dir)
+        self.addLinks((r1, r2), (r1, r3), (r3, r4))
+        super().build(*args, **kwargs)
+
+
+@require_root
+def test_openr_connectivity():
+    try:
+        net = IPNet(topo=SimpleOpenrTopo())
+        net.start()
+        assert_connectivity(net, v6=True)
+        net.stop()
+    finally:
+        cleanup()
+
+
+@require_root
+def test_logdir_creation():
+    try:
+        topo = SimpleOpenrTopo()
+        net = IPNet(topo=topo)
+        net.start()
+
+        log_dir = '/var/tmp/log'
+        log_dir_content = os.listdir('/var/tmp/log')
+
+        for i in range(1, 4):
+            assert f'r{i}' in log_dir_content
+
+        assert not 'r4' in log_dir_content
+        assert os.path.isdir(topo.r4_log_dir)
+
+        net.stop()
+    finally:
+        cleanup()
+
+
+@require_root
+def test_tmp_isolation():
+    try:
+        net = IPNet(topo=SimpleOpenrTopo())
+        net.start()
+
+        tmp_dir = '/tmp'
+        with tempfile.NamedTemporaryFile(dir=tmp_dir) as f:
+            file_base_name = os.path.basename(f.name)
+            host_tmp_dir_content = os.listdir(tmp_dir)
+
+            assert file_base_name in host_tmp_dir_content
+
+            for i in range(1, 4):
+                node_tmp_dir_content = net[f'r{i}'].cmd('ls /tmp').split()
+                assert not file_base_name in node_tmp_dir_content
+
+        file_name = 'foo'
+        net['r1'].cmd(f'touch /tmp/{file_name}')
+        node_tmp_dir_content = net['r1'].cmd('ls /tmp').split()
+        assert file_name in node_tmp_dir_content
+
+        host_tmp_dir_content = os.listdir(tmp_dir)
+        assert not file_name in host_tmp_dir_content
+
+        net.stop()
+    finally:
+        cleanup()

--- a/ipmininet/tests/test_openr.py
+++ b/ipmininet/tests/test_openr.py
@@ -1,12 +1,12 @@
-import pytest
 import os
 import tempfile
 import uuid
 
+import pytest
+
 from ipmininet.clean import cleanup
 from ipmininet.ipnet import IPNet
 from ipmininet.iptopo import IPTopo
-from ipmininet.router import OpenrRouter
 from ipmininet.node_description import OpenrRouterDescription
 from ipmininet.router import OpenrRouter
 from ipmininet.router.config import OpenrRouterConfig
@@ -21,16 +21,17 @@ class SimpleOpenrTopo(IPTopo):
         super().__init__(*args, **kwargs)
 
     def build(self, *args, **kwargs):
-        r1, r2, r3 = \
-            self.addRouters('r1', 'r2', 'r3',
+        # pylint: disable=unbalanced-tuple-unpacking
+        r_1, r_2, r_3 = \
+            self.addRouters('r_1', 'r_2', 'r_3',
                             cls=OpenrRouter,
                             routerDescription=OpenrRouterDescription,
                             config=OpenrRouterConfig)
-        r4 = self.addRouter('r4',
-                            cls=OpenrRouter,
-                            routerDescription=OpenrRouterDescription)
-        r4.addOpenrDaemon(log_dir=self.r4_log_dir)
-        self.addLinks((r1, r2), (r1, r3), (r3, r4))
+        r_4 = self.addRouter('r_4',
+                             cls=OpenrRouter,
+                             routerDescription=OpenrRouterDescription)
+        r_4.addOpenrDaemon(log_dir=self.r4_log_dir)
+        self.addLinks((r_1, r_2), (r_1, r_3), (r_3, r_4))
         super().build(*args, **kwargs)
 
 
@@ -55,8 +56,8 @@ def test_logdir_creation():
         default_log_dir = '/var/tmp/log'
 
         for i in range(1, 4):
-            assert os.path.isdir('{}/r{}'.format(default_log_dir, i))
-        assert not os.path.isdir('{}/r4'.format(default_log_dir))
+            assert os.path.isdir('{}/r_{}'.format(default_log_dir, i))
+        assert not os.path.isdir('{}/r_4'.format(default_log_dir))
         assert os.path.isdir(topo.r4_log_dir)
 
         net.stop()
@@ -71,29 +72,29 @@ def test_tmp_isolation():
         net.start()
 
         tmp_dir = '/tmp'
-        with tempfile.NamedTemporaryFile(dir=tmp_dir) as f:
-            host_file_name = f.name
+        with tempfile.NamedTemporaryFile(dir=tmp_dir) as file:
+            host_file_name = file.name
             host_file_base_name = os.path.basename(host_file_name)
             host_tmp_dir_content = os.listdir(tmp_dir)
 
             assert os.path.isfile(host_file_name)
             assert host_file_base_name in host_tmp_dir_content
             for i in range(1, 5):
-                node_tmp_dir_content = net['r{}'.format(i)] \
+                node_tmp_dir_content = net['r_{}'.format(i)] \
                                        .cmd('ls {}'.format(tmp_dir)) \
                                        .split()
-                assert not host_file_base_name in node_tmp_dir_content
+                assert host_file_base_name not in node_tmp_dir_content
 
         node_file_base_name = str(uuid.uuid1())
         node_file_name = '{}/{}'.format(tmp_dir,
                                         node_file_base_name)
-        net['r1'].cmd('touch {}'.format(node_file_name))
-        node_tmp_dir_content = net['r1'].cmd('ls {}'.format(tmp_dir)).split()
+        net['r_1'].cmd('touch {}'.format(node_file_name))
+        node_tmp_dir_content = net['r_1'].cmd('ls {}'.format(tmp_dir)).split()
         host_tmp_dir_content = os.listdir(tmp_dir)
 
         assert node_file_base_name in node_tmp_dir_content
         assert not os.path.isfile(node_file_name)
-        assert not node_file_base_name in host_tmp_dir_content
+        assert node_file_base_name not in host_tmp_dir_content
 
         net.stop()
     finally:

--- a/ipmininet/tests/test_openr.py
+++ b/ipmininet/tests/test_openr.py
@@ -2,8 +2,6 @@ import os
 import tempfile
 import uuid
 
-import pytest
-
 from ipmininet.clean import cleanup
 from ipmininet.ipnet import IPNet
 from ipmininet.iptopo import IPTopo

--- a/ipmininet/tests/test_openr.py
+++ b/ipmininet/tests/test_openr.py
@@ -55,8 +55,8 @@ def test_logdir_creation():
         default_log_dir = '/var/tmp/log'
 
         for i in range(1, 4):
-            assert os.path.isdir(f'{default_log_dir}/r{i}')
-        assert not os.path.isdir(f'{default_log_dir}/r4')
+            assert os.path.isdir('{}/r{}'.format(default_log_dir, i))
+        assert not os.path.isdir('{}/r4'.format(default_log_dir))
         assert os.path.isdir(topo.r4_log_dir)
 
         net.stop()
@@ -79,14 +79,16 @@ def test_tmp_isolation():
             assert os.path.isfile(host_file_name)
             assert host_file_base_name in host_tmp_dir_content
             for i in range(1, 5):
-                node_tmp_dir_content = net[f'r{i}'].cmd(f'ls {tmp_dir}') \
-                                                   .split()
+                node_tmp_dir_content = net['r{}'.format(i)] \
+                                       .cmd('ls {}'.format(tmp_dir)) \
+                                       .split()
                 assert not host_file_base_name in node_tmp_dir_content
 
         node_file_base_name = str(uuid.uuid1())
-        node_file_name = f'{tmp_dir}/{node_file_base_name}'
-        net['r1'].cmd(f'touch {node_file_name}')
-        node_tmp_dir_content = net['r1'].cmd(f'ls {tmp_dir}').split()
+        node_file_name = '{}/{}'.format(tmp_dir,
+                                        node_file_base_name)
+        net['r1'].cmd('touch {}'.format(node_file_name))
+        node_tmp_dir_content = net['r1'].cmd('ls {}'.format(tmp_dir)).split()
         host_tmp_dir_content = os.listdir(tmp_dir)
 
         assert node_file_base_name in node_tmp_dir_content


### PR DESCRIPTION
This PR adds automatic daemon logdir creation on Node startup. `NodeDescriptions` are factored out from `IPTopo`.

This PR also includes some changes for the OpenR daemon:
- New classes: OpenrRouter, OpenrRouterConfig, OpenrRouterDescription
- Private `/tmp` dirs for OpenR nodes
- Improvements for the OpenR default configuration
- Small refactorings