### PR TITLE
hardcoded address replaced by router-id

### DIFF
--- a/ipmininet/router/config/templates/bgpd.mako
+++ b/ipmininet/router/config/templates/bgpd.mako
@@ -48,7 +48,7 @@ router bgp ${node.bgpd.asn}
         % endif
     % endfor
     % if node.bgpd.rr:
-    bgp cluster-id 10.0.0.0
+    bgp cluster-id ${node.bgpd.routerid}
     % endif
 % endfor
 


### PR DESCRIPTION
In order to avoid having the same cluster ID for all the different RRs, we have set the cluster-id to the router-id.