### PR TITLE
Fix CommunityList example in daemons.rst

### DIFF
--- a/docs/daemons.rst
+++ b/docs/daemons.rst
@@ -104,7 +104,7 @@ The following code shows how to use all these abstractions:
             all_al = AccessList('all', ('any',))
 
             # Add a community list to as2r1
-            loc_pref = CommunityList('loc-pref', '2:80')
+            loc_pref = CommunityList('loc-pref', community='2:80')
 
             # as2r1 set the local pref of all the route coming from as1r1 and matching the community list community to 80
             as2r1.get_config(BGP).set_local_pref(80, from_peer=as1r1, matching=(loc_pref,))


### PR DESCRIPTION
Hello,

This PR meant to fix an error in the documentation for the BGP Daemon example.
The CommunityList class has 3 optional parameters, the actual example set the "name" parameter to 'local-pref' and the "action" parameter to "2:80". Instead of setting the "name" and the "community" parameters.

Resulting in this line in the router configuration:
`bgp community-list loc-pref 2:80 1:0 `
However it should be:
`bgp community-list loc-pref PERMIT 2:80`
