### PR TITLE
Fix OSPF area configuration for loopback interface

### DIFF
--- a/ipmininet/router/__router.py
+++ b/ipmininet/router/__router.py
@@ -250,7 +250,9 @@ class Router(IPNode, L3Router):
 
         # This interface already exists in the node,
         # so no need to move it
-        lo = IPIntf('lo', node=self, port=-1, moveIntfFn=lambda x, y: None)
+        node_params_for_lo = ["igp_area"]
+        params = {k: v for k, v in kwargs.items() if k in node_params_for_lo}
+        lo = IPIntf('lo', node=self, port=-1, moveIntfFn=lambda x, y: None, **params)
         lo.ip = lo_addresses
 
     @property

--- a/ipmininet/router/config/ospf.py
+++ b/ipmininet/router/config/ospf.py
@@ -28,6 +28,8 @@ class OSPFArea(Overlay):
     @area.setter
     def area(self, x: str):
         self.links_properties['igp_area'] = x
+        # Also set node property so we can use it for the loopback interface
+        self.nodes_properties['igp_area'] = x
 
     def apply(self, topo):
         # Add all links for the routers


### PR DESCRIPTION
Currently, the loopback interface of a router is always assigned to OSPF (v2&3) area 0. On a router without a direct connection to area 0, this makes addresses assigned to the loopback interface unreachable for other routers.

This PR makes the existing igp_area link parameter also a node parameter so that a router can access it and use its value when configuring the loopback interface.

Note that I'm not 100% sure that this PR follows IPMininet's spirit for passing around configuration parameters. Better ideas about how to solve this issue are always welcome, of course ;-)

Test case:
```python
import ipmininet
from ipmininet.router.config import OSPF6, RouterConfig
from ipmininet.iptopo import IPTopo
from ipmininet.ipnet import IPNet
from ipmininet.cli import IPCLI


# Topology:
#    +----------+
#    |          |
#    |    r1    |
#    |          |
#    +--|eth0|--+
#         |
#         |
#    +--|eth0|--+
#    |          |
#    |    r2    | area 0
# ...|          |........
#    +--|eth1|--+ area 1
#         |
#         |
#    +--|eth0|--+
#    |          |
#    |    r3    |
#    |          |
#    +----------+

class Ospfv3MultiAreaTopo(IPTopo):
  def build(self, *args, **kwargs):
    r1 = self.addRouter("r1", config=RouterConfig, lo_addresses=["fc00::1/128"])
    r1.addDaemon(OSPF6)
    r2 = self.addRouter("r2", config=RouterConfig, lo_addresses=["fc00::2/128"])
    r2.addDaemon(OSPF6)
    r3 = self.addRouter("r3", config=RouterConfig, lo_addresses=["fc00::3/128"])
    r3.addDaemon(OSPF6)
    
    self.addLink(r1, r2)
    self.addLink(r2, r3)
    
    self.addOSPFArea(routers=(r3,), area="0.0.0.1")
    
    super().build(*args, **kwargs)
  
  
if __name__ == "__main__":
  net = IPNet(topo=Ospfv3MultiAreaTopo(), use_v4=False, allocate_IPs=False)
  try:
    net.start()
    IPCLI(net)
  finally:
    net.stop()
```

Expected result:
```
mininet> r1 ip -6 r
unreachable fc00::1 dev lo proto kernel metric 256 error -101 pref medium
fc00::2 via fe80::b0a9:b2ff:fe2a:6828 dev r1-eth0 proto 188 metric 20 pref medium
fc00::3 via fe80::b0a9:b2ff:fe2a:6828 dev r1-eth0 proto 188 metric 20 pref medium
fe80::/64 dev r1-eth0 proto kernel metric 256 pref medium
```

Actual result without this PR:
```
mininet> r1 ip -6 r
unreachable fc00::1 dev lo proto kernel metric 256 error -101 pref medium
fc00::2 via fe80::b40d:6cff:fe8d:2159 dev r1-eth0 proto 188 metric 20 pref medium
fe80::/64 dev r1-eth0 proto kernel metric 256 pref medium
```

Note that the route to fc00::3/128 (loopback on r3) is not visible on r1 without this PR because ospf6d_r3.cfg contains this:
```
hostname r3
[...]
router ospf6
  ospf6 router-id 0.0.0.4
  interface lo area 0.0.0.0
  interface r3-eth0 area 0.0.0.1
```

With this PR applied, it looks like this:
```
hostname r3
[...]
router ospf6
  ospf6 router-id 0.0.0.4
  interface lo area 0.0.0.1
  interface r3-eth0 area 0.0.0.1
```
