### PR TITLE
Add support for FRR vtysh

### DIFF
--- a/ipmininet/router/config/base.py
+++ b/ipmininet/router/config/base.py
@@ -64,7 +64,8 @@ class NodeConfig:
         host_file_mount = os.path.join(self._node.cwd, 'hosts_%(name)s')
         self.build_host_file(host_file_mount % self._node.__dict__)
         self.add_private_fs_path([('/etc/resolv.conf', resolv_file_mount),
-                                  ('/etc/hosts', host_file_mount)])
+                                  ('/etc/hosts', host_file_mount),
+                                  '/var/run/frr'])
 
         self._cfg.clear()
         self._cfg.name = self._node.name


### PR DESCRIPTION
vtysh in FRR by default uses Unix domain sockets in /var/run/frr to access
the CLI of routing daemons. So far, running vtysh always caused it to
connect to the most recently started FRR daemons because they created their
sockets last and thus overwrote those of earlier daemons. This commit makes
/var/run/frr a private directory specific to each router, so running vtysh
in the router's namespace makes it connect to the daemons responsible for
that router.

I don't know which directory was used by the pre-FRR Quagga (maybe
/var/run/quagga?), but it proabably simply could be added to the list and
we'd have vtysh support both for FRR and Quagga in case somebody is still
using the latter.

Signed-off-by: Martin Buck <mb-tmp-tvguho.pbz@gromit.dyndns.org>